### PR TITLE
[Fix] Correct transaction count display in Activity view

### DIFF
--- a/pages/popup/src/04_Dashboard/[currency]/Activity.tsx
+++ b/pages/popup/src/04_Dashboard/[currency]/Activity.tsx
@@ -92,7 +92,7 @@ export const Activity: React.FC = () => {
         <div className="flex flex-col w-full gap-[7px]">
           <div className="flex justify-between items-center">
             <span className="text-white text-sm font-bold">Activity</span>
-            <span className="text-white text-sm">{formatNumber(history.length)} total</span>
+            <span className="text-white text-sm">{formatNumber(txHistory?.length || 0)} total</span>
           </div>
           {loading ? (
             <>


### PR DESCRIPTION
This PR addresses a bug in the Activity view where an incorrect variable (`history.length`) was used to display the total number of transactions. This lead to inaccurate counts , generally incrementing the count each time receive button is pressed.

The fix updates the component to use `txHistory?.length || 0`. This ensures that:
- The correct `txHistory` array, fetched from the wallet context for the selected account, is used for the count.
- Optional chaining (`?.`) gracefully handles cases where `txHistory` might be initially undefined (e.g., during loading).
- The `|| 0` fallback ensures '0' is displayed if `txHistory` is null, undefined, or empty, preventing `NaN` or runtime errors.

This change ensures the "Activity" section accurately reflects the total number of transactions for the user's selected account.