### PR TITLE
Fix in memory did not clear encrypted vault

### DIFF
--- a/packages/backend/src/modules/wallet.ts
+++ b/packages/backend/src/modules/wallet.ts
@@ -326,6 +326,8 @@ export class Wallet {
       await chrome.storage.local.remove(WALLET_KEY);
     } finally {
       this.clear();
+      this.encryptedVault = null;
+      this.network = undefined;
     }
   }
 }

--- a/pages/popup/src/context/WalletContext.tsx
+++ b/pages/popup/src/context/WalletContext.tsx
@@ -258,7 +258,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       _setChainBalances({});
       setChainBalancesLoading(false);
       setHasHydratedChainBalances(false);
-      setUnlocked(true);
+      setUnlocked(false);
     })();
   };
 


### PR DESCRIPTION
Currently the `wallet.destroy()` removes the encrypted vault from persistent storage `chrome.storage.local` but the in-memory `this.encryptedVault` is not nulified. The `clear()` method only clear in-memory `root` and `xpub`. The wallet singleton lives in the background service worker so it survives popup close/reopen. 