### PR TITLE
Improve Scan Strategy

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -88,8 +88,37 @@ browser.runtime.onInstalled.addListener(() => {
 
 function setupAlarms() {
   browser.alarms.create('forwardScan', { periodInMinutes: 3 });
-  browser.alarms.create('backfillScan', { periodInMinutes: 0.1 });
+  // Chrome clamps alarms below 30s, and a 6s period (0.1) was both clamped and
+  // wasteful. Backfill only needs to react within a block (~10 min); 1 min keeps
+  // confirmation status fresh without burning service-worker wakeups.
+  browser.alarms.create('backfillScan', { periodInMinutes: 1 });
 }
+
+// Kick a scan whenever the popup opens. The popup connects via the 'chui-app'
+// port (see registerMessagePort), and that connection keeps the SW alive while
+// the popup is in use, so the scan completes on the same wakeup. The inflight
+// promise dedupes rapid reconnects (e.g. popup re-open while a scan is running).
+let scanKickoffInflight: Promise<void> | null = null;
+async function kickoffScan() {
+  if (scanKickoffInflight) return scanKickoffInflight;
+  if (accountManager.activeAccountIndex < 0) return;
+  scanKickoffInflight = (async () => {
+    try {
+      await forwardScan();
+      await backfillScan();
+    } catch (err) {
+      logger.error('Popup-open scan kickoff failed', err);
+    } finally {
+      scanKickoffInflight = null;
+    }
+  })();
+  return scanKickoffInflight;
+}
+
+browser.runtime.onConnect.addListener(port => {
+  if (port.name !== 'chui-app') return;
+  void kickoffScan();
+});
 
 browser.alarms.onAlarm.addListener(async alarm => {
   if (alarm.name === 'forwardScan') {

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -94,11 +94,10 @@ function setupAlarms() {
   browser.alarms.create('backfillScan', { periodInMinutes: 1 });
 }
 
-// Kick a scan whenever the popup opens so users see fresh state on open instead
-// of waiting for the next alarm. Concurrent kickoffs and overlapping alarms are
-// coalesced inside scanManager (per-changeType inflight promise), so re-opening
-// the popup while an alarm-triggered scan is mid-flight does not start a second
-// Electrum round trip.
+// 'chui-app' is opened only by the popup (pages/popup/src/hooks/useChuiEvents.ts);
+// reusing the name from a content script would let any page induce a scan.
+// Sibling listener in messaging/port.ts handles the port lifecycle; this one
+// only triggers a scan kickoff. Dedupe lives in scanManager.
 browser.runtime.onConnect.addListener(port => {
   if (port.name !== 'chui-app') return;
   if (accountManager.activeAccountIndex < 0) return;

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -94,30 +94,15 @@ function setupAlarms() {
   browser.alarms.create('backfillScan', { periodInMinutes: 1 });
 }
 
-// Kick a scan whenever the popup opens. The popup connects via the 'chui-app'
-// port (see registerMessagePort), and that connection keeps the SW alive while
-// the popup is in use, so the scan completes on the same wakeup. The inflight
-// promise dedupes rapid reconnects (e.g. popup re-open while a scan is running).
-let scanKickoffInflight: Promise<void> | null = null;
-async function kickoffScan() {
-  if (scanKickoffInflight) return scanKickoffInflight;
-  if (accountManager.activeAccountIndex < 0) return;
-  scanKickoffInflight = (async () => {
-    try {
-      await forwardScan();
-      await backfillScan();
-    } catch (err) {
-      logger.error('Popup-open scan kickoff failed', err);
-    } finally {
-      scanKickoffInflight = null;
-    }
-  })();
-  return scanKickoffInflight;
-}
-
+// Kick a scan whenever the popup opens so users see fresh state on open instead
+// of waiting for the next alarm. Concurrent kickoffs and overlapping alarms are
+// coalesced inside scanManager (per-changeType inflight promise), so re-opening
+// the popup while an alarm-triggered scan is mid-flight does not start a second
+// Electrum round trip.
 browser.runtime.onConnect.addListener(port => {
   if (port.name !== 'chui-app') return;
-  void kickoffScan();
+  if (accountManager.activeAccountIndex < 0) return;
+  void allScan().catch(err => logger.error('Popup-open scan kickoff failed', err));
 });
 
 browser.alarms.onAlarm.addListener(async alarm => {

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -88,16 +88,10 @@ browser.runtime.onInstalled.addListener(() => {
 
 function setupAlarms() {
   browser.alarms.create('forwardScan', { periodInMinutes: 3 });
-  // Chrome clamps alarms below 30s, and a 6s period (0.1) was both clamped and
-  // wasteful. Backfill only needs to react within a block (~10 min); 1 min keeps
-  // confirmation status fresh without burning service-worker wakeups.
   browser.alarms.create('backfillScan', { periodInMinutes: 1 });
 }
 
-// 'chui-app' is opened only by the popup (pages/popup/src/hooks/useChuiEvents.ts);
-// reusing the name from a content script would let any page induce a scan.
-// Sibling listener in messaging/port.ts handles the port lifecycle; this one
-// only triggers a scan kickoff. Dedupe lives in scanManager.
+// 'chui-app' must remain popup-only; a content script reusing this name would let any page induce a scan.
 browser.runtime.onConnect.addListener(port => {
   if (port.name !== 'chui-app') return;
   if (accountManager.activeAccountIndex < 0) return;

--- a/packages/backend/src/modules/electrumServer.ts
+++ b/packages/backend/src/modules/electrumServer.ts
@@ -9,7 +9,6 @@ export const availableServerList: ServerConfig[] = [
   { host: 'b.1209k.com', port: DefaultPort.TLS, useTls: true, network: Network.Mainnet },
   { host: 'testnet4.electrs.btcscan.net', port: 443, useTls: true, network: Network.Testnet },
   { host: 'testnet4.electrum.blockonomics.co', port: 443, useTls: true, network: Network.Testnet },
-  x,
 ];
 
 export async function selectBestServer(network: Network): Promise<ExtendedServerConfig> {

--- a/packages/backend/src/modules/txHistoryService.ts
+++ b/packages/backend/src/modules/txHistoryService.ts
@@ -25,8 +25,21 @@ type OutPart = { address: string; valueSat: bigint; mine: boolean };
 export class TxHistoryService {
   private txHistoryCache = new Map<string, TxEntry>();
   private parentTxCache = new Map<string, ElectrumTransaction>();
+  // Serialises load->mutate->save: loadTxHistory() clears the in-memory cache,
+  // so concurrent writers would clobber each other.
+  private writeQueue: Promise<unknown> = Promise.resolve();
+
+  private withLock<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.writeQueue.then(fn, fn);
+    this.writeQueue = next.catch(() => undefined);
+    return next;
+  }
 
   public async get(): Promise<TxEntry[]> {
+    return this.withLock(() => this.runGet());
+  }
+
+  private async runGet(): Promise<TxEntry[]> {
     await this.loadTxHistory();
     const histories = [...scanManager['historyCacheReceive'].values(), ...scanManager['historyCacheChange'].values()];
     const bitcoinPrice = await getBitcoinPrice();
@@ -238,34 +251,36 @@ export class TxHistoryService {
    * canonical one on the next get() once the scanner picks the tx up (see the
    * status === 'PENDING' refresh branch in get()).
    */
-  public async addOptimisticPending(args: {
+  public addOptimisticPending(args: {
     txid: string;
     toAddress: string;
     fromAddress: string;
     amountSats: number;
     feeSats: number;
   }): Promise<void> {
-    await this.loadTxHistory();
-    if (this.txHistoryCache.has(args.txid)) return;
+    return this.withLock(async () => {
+      await this.loadTxHistory();
+      if (this.txHistoryCache.has(args.txid)) return;
 
-    const btcUsdRate = await getBitcoinPrice().catch(() => undefined);
-    const amountBtc = args.amountSats / 1e8;
-    const feeBtc = args.feeSats / 1e8;
-    const entry: TxEntry = {
-      type: 'SEND',
-      status: 'PENDING',
-      amountBtc,
-      amountUsd: typeof btcUsdRate === 'number' ? amountBtc * btcUsdRate : undefined,
-      feeBtc,
-      feeUsd: typeof btcUsdRate === 'number' ? feeBtc * btcUsdRate : undefined,
-      timestamp: Date.now(),
-      confirmations: 0,
-      transactionHash: args.txid,
-      sender: args.fromAddress,
-      receiver: args.toAddress,
-    };
-    this.txHistoryCache.set(args.txid, entry);
-    await this.saveTxHistory();
+      const btcUsdRate = await getBitcoinPrice().catch(() => undefined);
+      const amountBtc = args.amountSats / 1e8;
+      const feeBtc = args.feeSats / 1e8;
+      const entry: TxEntry = {
+        type: 'SEND',
+        status: 'PENDING',
+        amountBtc,
+        amountUsd: btcUsdRate ? amountBtc * btcUsdRate : 0,
+        feeBtc,
+        feeUsd: btcUsdRate ? feeBtc * btcUsdRate : 0,
+        timestamp: Date.now(),
+        confirmations: 0,
+        transactionHash: args.txid,
+        sender: args.fromAddress,
+        receiver: args.toAddress,
+      };
+      this.txHistoryCache.set(args.txid, entry);
+      await this.saveTxHistory();
+    });
   }
 
   public async clearCache(): Promise<void> {

--- a/packages/backend/src/modules/txHistoryService.ts
+++ b/packages/backend/src/modules/txHistoryService.ts
@@ -244,13 +244,6 @@ export class TxHistoryService {
     }
   }
 
-  /**
-   * Insert a synthetic PENDING entry for a tx the wallet just broadcast.
-   * Lets the activity list reflect the send instantly instead of waiting for
-   * the next scan to discover it via mempool. The entry is replaced with the
-   * canonical one on the next get() once the scanner picks the tx up (see the
-   * status === 'PENDING' refresh branch in get()).
-   */
   public addOptimisticPending(args: {
     txid: string;
     toAddress: string;

--- a/packages/backend/src/modules/txHistoryService.ts
+++ b/packages/backend/src/modules/txHistoryService.ts
@@ -231,6 +231,43 @@ export class TxHistoryService {
     }
   }
 
+  /**
+   * Insert a synthetic PENDING entry for a tx the wallet just broadcast.
+   * Lets the activity list reflect the send instantly instead of waiting for
+   * the next scan to discover it via mempool. The entry is replaced with the
+   * canonical one on the next get() once the scanner picks the tx up (see the
+   * status === 'PENDING' refresh branch in get()).
+   */
+  public async addOptimisticPending(args: {
+    txid: string;
+    toAddress: string;
+    fromAddress: string;
+    amountSats: number;
+    feeSats: number;
+  }): Promise<void> {
+    await this.loadTxHistory();
+    if (this.txHistoryCache.has(args.txid)) return;
+
+    const btcUsdRate = await getBitcoinPrice().catch(() => undefined);
+    const amountBtc = args.amountSats / 1e8;
+    const feeBtc = args.feeSats / 1e8;
+    const entry: TxEntry = {
+      type: 'SEND',
+      status: 'PENDING',
+      amountBtc,
+      amountUsd: typeof btcUsdRate === 'number' ? amountBtc * btcUsdRate : undefined,
+      feeBtc,
+      feeUsd: typeof btcUsdRate === 'number' ? feeBtc * btcUsdRate : undefined,
+      timestamp: Date.now(),
+      confirmations: 0,
+      transactionHash: args.txid,
+      sender: args.fromAddress,
+      receiver: args.toAddress,
+    };
+    this.txHistoryCache.set(args.txid, entry);
+    await this.saveTxHistory();
+  }
+
   public async clearCache(): Promise<void> {
     try {
       await browser.storage.local.remove(getCacheKey(CacheType.Tx, ChangeType.External));

--- a/packages/backend/src/scanManager.ts
+++ b/packages/backend/src/scanManager.ts
@@ -43,6 +43,11 @@ export class ScanManager {
   public nextChangeIndex = 0;
   public readonly onStatus = createEmitter<ScanEvent>();
   private epoch = 0;
+  // Coalesce concurrent scan requests so alarm + popup-open + post-send triggers
+  // share one Electrum round-trip per (kind, changeType) instead of stacking up
+  // and tripping rate limits. See issue #15.
+  private forwardInflight = new Map<ChangeType, Promise<void>>();
+  private backfillInflight = new Map<ChangeType, Promise<void>>();
 
   constructor(config: ScanManagerConfig = defaultScanConfig) {
     this.config = { ...config };
@@ -72,7 +77,15 @@ export class ScanManager {
    * Forward scan the address chain by deriving to gapLimit
    * @param changeType
    */
-  public async forwardScan(changeType: ChangeType = ChangeType.External) {
+  public async forwardScan(changeType: ChangeType = ChangeType.External): Promise<void> {
+    const existing = this.forwardInflight.get(changeType);
+    if (existing) return existing;
+    const p = this.runForwardScan(changeType).finally(() => this.forwardInflight.delete(changeType));
+    this.forwardInflight.set(changeType, p);
+    return p;
+  }
+
+  private async runForwardScan(changeType: ChangeType): Promise<void> {
     const startEpoch = this.epoch;
     let passes = 0;
     while (passes < this.config.forwardExtendMaxPasses) {
@@ -111,7 +124,15 @@ export class ScanManager {
    * Backfill scan continuously scan unused derived addresses within threshold limit (days) order by staleness, in batch of staleBatchSize
    * @param changeType
    */
-  public async backfillScan(changeType: ChangeType = ChangeType.External) {
+  public async backfillScan(changeType: ChangeType = ChangeType.External): Promise<void> {
+    const existing = this.backfillInflight.get(changeType);
+    if (existing) return existing;
+    const p = this.runBackfillScan(changeType).finally(() => this.backfillInflight.delete(changeType));
+    this.backfillInflight.set(changeType, p);
+    return p;
+  }
+
+  private async runBackfillScan(changeType: ChangeType): Promise<void> {
     const startEpoch = this.epoch;
     const gapLimit = selectByChain(this.config.externalGapLimit, this.config.internalGapLimit, changeType);
     const highestUsed = selectByChain(this.highestUsedReceive, this.highestUsedChange, changeType);

--- a/packages/backend/src/scanManager.ts
+++ b/packages/backend/src/scanManager.ts
@@ -77,7 +77,10 @@ export class ScanManager {
    * Forward scan the address chain by deriving to gapLimit
    * @param changeType
    */
-  public async forwardScan(changeType: ChangeType = ChangeType.External): Promise<void> {
+  // Not async: returning the cached promise directly (rather than via an async
+  // wrapper that would re-wrap it in a fresh Promise) preserves identity, which
+  // matters for callers that need to know "am I joining the same scan?".
+  public forwardScan(changeType: ChangeType = ChangeType.External): Promise<void> {
     const existing = this.forwardInflight.get(changeType);
     if (existing) return existing;
     const p = this.runForwardScan(changeType).finally(() => this.forwardInflight.delete(changeType));
@@ -124,7 +127,7 @@ export class ScanManager {
    * Backfill scan continuously scan unused derived addresses within threshold limit (days) order by staleness, in batch of staleBatchSize
    * @param changeType
    */
-  public async backfillScan(changeType: ChangeType = ChangeType.External): Promise<void> {
+  public backfillScan(changeType: ChangeType = ChangeType.External): Promise<void> {
     const existing = this.backfillInflight.get(changeType);
     if (existing) return existing;
     const p = this.runBackfillScan(changeType).finally(() => this.backfillInflight.delete(changeType));

--- a/packages/backend/src/scanManager.ts
+++ b/packages/backend/src/scanManager.ts
@@ -43,9 +43,8 @@ export class ScanManager {
   public nextChangeIndex = 0;
   public readonly onStatus = createEmitter<ScanEvent>();
   private epoch = 0;
-  // Coalesce concurrent scan requests so alarm + popup-open + post-send triggers
-  // share one Electrum round-trip per (kind, changeType) instead of stacking up
-  // and tripping rate limits. See issue #15.
+  // Coalesce concurrent scans so triggers share one Electrum round-trip per
+  // (kind, changeType). See #15.
   private forwardInflight = new Map<ChangeType, Promise<void>>();
   private backfillInflight = new Map<ChangeType, Promise<void>>();
 
@@ -77,9 +76,8 @@ export class ScanManager {
    * Forward scan the address chain by deriving to gapLimit
    * @param changeType
    */
-  // Not async: returning the cached promise directly (rather than via an async
-  // wrapper that would re-wrap it in a fresh Promise) preserves identity, which
-  // matters for callers that need to know "am I joining the same scan?".
+  // Not async: an async wrapper would re-wrap the cached promise in a fresh
+  // one (per spec), breaking the identity check the dedupe test relies on.
   public forwardScan(changeType: ChangeType = ChangeType.External): Promise<void> {
     const existing = this.forwardInflight.get(changeType);
     if (existing) return existing;

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -270,13 +270,11 @@ export class WalletManager {
     const txHex = wallet.signPsbt(selectedUtxo.inputs, psbt);
     const txid = await electrumService.broadcastTx(txHex!);
 
-    // Show the send in the activity list immediately. The next scan that picks
-    // up the tx in mempool will overwrite this with the canonical entry.
     try {
       await historyService.addOptimisticPending({
         txid,
         toAddress: to,
-        fromAddress: selectedUtxo.inputs[0]?.address ?? '',
+        fromAddress: selectedUtxo.inputs[0].address,
         amountSats,
         feeSats: selectedUtxo.fee,
       });
@@ -284,11 +282,12 @@ export class WalletManager {
       logger.warn('Failed to record optimistic pending tx', err);
     }
 
-    // Trigger a forward scan so the new tx is picked up before the next alarm.
-    void scanManager.forwardScan().catch(err => logger.warn('Post-send forward scan failed', err));
-    void scanManager
-      .forwardScan(ChangeType.Internal)
-      .catch(err => logger.warn('Post-send change-chain scan failed', err));
+    // Awaited (not fire-and-forget) so the MV3 service worker stays alive long
+    // enough for the canonical entry to replace the optimistic one.
+    await Promise.allSettled([
+      scanManager.forwardScan().catch(err => logger.warn('Post-send forward scan failed', err)),
+      scanManager.forwardScan(ChangeType.Internal).catch(err => logger.warn('Post-send change-chain scan failed', err)),
+    ]);
 
     return txid;
   }

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -268,7 +268,29 @@ export class WalletManager {
       getPrevTxHex: (txid: string) => electrumService.getRawTransaction(txid), // Todo: only used for legacy P2PKH, consider depracation
     });
     const txHex = wallet.signPsbt(selectedUtxo.inputs, psbt);
-    return await electrumService.broadcastTx(txHex!);
+    const txid = await electrumService.broadcastTx(txHex!);
+
+    // Show the send in the activity list immediately. The next scan that picks
+    // up the tx in mempool will overwrite this with the canonical entry.
+    try {
+      await historyService.addOptimisticPending({
+        txid,
+        toAddress: to,
+        fromAddress: selectedUtxo.inputs[0]?.address ?? '',
+        amountSats,
+        feeSats: selectedUtxo.fee,
+      });
+    } catch (err) {
+      logger.warn('Failed to record optimistic pending tx', err);
+    }
+
+    // Trigger a forward scan so the new tx is picked up before the next alarm.
+    void scanManager.forwardScan().catch(err => logger.warn('Post-send forward scan failed', err));
+    void scanManager
+      .forwardScan(ChangeType.Internal)
+      .catch(err => logger.warn('Post-send change-chain scan failed', err));
+
+    return txid;
   }
 
   /**

--- a/packages/backend/tests/modules/scanManager.test.ts
+++ b/packages/backend/tests/modules/scanManager.test.ts
@@ -1,4 +1,5 @@
-import { computeForwardScanWindow } from '../../src/scanManager';
+import { computeForwardScanWindow, ScanManager } from '../../src/scanManager';
+import { ChangeType } from '../../src/types/cache';
 
 describe('computeForwardScanWindow', () => {
   it('returns gap+1 from a fresh wallet (no usage, nothing scanned)', () => {
@@ -24,5 +25,73 @@ describe('computeForwardScanWindow', () => {
   it('handles a small gap limit', () => {
     expect(computeForwardScanWindow(0, 1, 0)).toBe(1);
     expect(computeForwardScanWindow(0, 1, 1)).toBe(0);
+  });
+});
+
+describe('ScanManager — concurrent scan dedupe', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('forwardScan returns the same in-flight promise for concurrent calls on the same chain', async () => {
+    const sm = new ScanManager();
+    const spy = jest
+      .spyOn(sm as unknown as { runForwardScan: () => Promise<void> }, 'runForwardScan')
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 30)));
+
+    const a = sm.forwardScan(ChangeType.External);
+    const b = sm.forwardScan(ChangeType.External);
+    expect(a).toBe(b);
+    await a;
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwardScan runs External and Internal in parallel (different inflight slots)', async () => {
+    const sm = new ScanManager();
+    const spy = jest
+      .spyOn(sm as unknown as { runForwardScan: () => Promise<void> }, 'runForwardScan')
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 30)));
+
+    const ext = sm.forwardScan(ChangeType.External);
+    const int = sm.forwardScan(ChangeType.Internal);
+    expect(ext).not.toBe(int);
+    await Promise.all([ext, int]);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('forwardScan starts a fresh scan after the previous one resolves', async () => {
+    const sm = new ScanManager();
+    const spy = jest
+      .spyOn(sm as unknown as { runForwardScan: () => Promise<void> }, 'runForwardScan')
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 5)));
+
+    await sm.forwardScan(ChangeType.External);
+    await sm.forwardScan(ChangeType.External);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('backfillScan dedupes concurrent calls on the same chain', async () => {
+    const sm = new ScanManager();
+    const spy = jest
+      .spyOn(sm as unknown as { runBackfillScan: () => Promise<void> }, 'runBackfillScan')
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 30)));
+
+    const a = sm.backfillScan(ChangeType.External);
+    const b = sm.backfillScan(ChangeType.External);
+    expect(a).toBe(b);
+    await a;
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwardScan and backfillScan can run in parallel (independent inflight maps)', async () => {
+    const sm = new ScanManager();
+    const fwdSpy = jest
+      .spyOn(sm as unknown as { runForwardScan: () => Promise<void> }, 'runForwardScan')
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 30)));
+    const bfSpy = jest
+      .spyOn(sm as unknown as { runBackfillScan: () => Promise<void> }, 'runBackfillScan')
+      .mockImplementation(() => new Promise(resolve => setTimeout(resolve, 30)));
+
+    await Promise.all([sm.forwardScan(ChangeType.External), sm.backfillScan(ChangeType.External)]);
+    expect(fwdSpy).toHaveBeenCalledTimes(1);
+    expect(bfSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/backend/tests/modules/scanManager.test.ts
+++ b/packages/backend/tests/modules/scanManager.test.ts
@@ -94,4 +94,28 @@ describe('ScanManager — concurrent scan dedupe', () => {
     expect(fwdSpy).toHaveBeenCalledTimes(1);
     expect(bfSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('forwardScan clears the inflight slot on rejection so the next call restarts', async () => {
+    const sm = new ScanManager();
+    const spy = jest
+      .spyOn(sm as unknown as { runForwardScan: () => Promise<void> }, 'runForwardScan')
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(sm.forwardScan(ChangeType.External)).rejects.toThrow('boom');
+    await sm.forwardScan(ChangeType.External);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('backfillScan clears the inflight slot on rejection so the next call restarts', async () => {
+    const sm = new ScanManager();
+    const spy = jest
+      .spyOn(sm as unknown as { runBackfillScan: () => Promise<void> }, 'runBackfillScan')
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(sm.backfillScan(ChangeType.External)).rejects.toThrow('boom');
+    await sm.backfillScan(ChangeType.External);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/backend/tests/modules/txHistoryService.test.ts
+++ b/packages/backend/tests/modules/txHistoryService.test.ts
@@ -217,4 +217,61 @@ describe('TxHistoryService.get', () => {
     const txKey = Object.keys(all).find(k => k.startsWith('tx_'));
     expect(txKey).toBeDefined();
   });
+
+  it('addOptimisticPending() inserts a SEND/PENDING entry surfaced by get()', async () => {
+    const svc = new TxHistoryService();
+    await svc.addOptimisticPending({
+      txid: 'pendingtx1',
+      toAddress: 'bc1qrecipient',
+      fromAddress: MY_RECEIVE,
+      amountSats: 100_000,
+      feeSats: 1_000,
+    });
+    const txs = await svc.get();
+    const pending = txs.find(t => t.transactionHash === 'pendingtx1')!;
+    expect(pending.type).toBe('SEND');
+    expect(pending.status).toBe('PENDING');
+    expect(pending.amountBtc).toBeCloseTo(0.001, 8);
+    expect(pending.feeBtc).toBeCloseTo(0.00001, 8);
+    expect(pending.receiver).toBe('bc1qrecipient');
+    expect(pending.sender).toBe(MY_RECEIVE);
+    expect(pending.amountUsd).toBeCloseTo(0.001 * 60_000, 5);
+  });
+
+  it('addOptimisticPending() is a no-op when an entry for the txid already exists', async () => {
+    setReceiveHistory(['recvtx1']);
+    mockAllTxs();
+    const svc = new TxHistoryService();
+    await svc.get(); // populates cache with the canonical recvtx1 entry
+    await svc.addOptimisticPending({
+      txid: 'recvtx1',
+      toAddress: 'bc1qsomeoneelse',
+      fromAddress: MY_RECEIVE,
+      amountSats: 999,
+      feeSats: 1,
+    });
+    const txs = await svc.get();
+    const recv = txs.find(t => t.transactionHash === 'recvtx1')!;
+    expect(recv.type).toBe('RECEIVE');
+    expect(recv.receiver).not.toBe('bc1qsomeoneelse');
+  });
+
+  it('addOptimisticPending() is replaced by the canonical entry once the scanner picks the tx up', async () => {
+    const svc = new TxHistoryService();
+    await svc.addOptimisticPending({
+      txid: 'recvtx1',
+      toAddress: MY_RECEIVE,
+      fromAddress: '',
+      amountSats: 50_000,
+      feeSats: 500,
+    });
+    expect((await svc.get()).find(t => t.transactionHash === 'recvtx1')!.status).toBe('PENDING');
+
+    setReceiveHistory(['recvtx1']);
+    mockAllTxs();
+    const txs = await svc.get();
+    const tx = txs.find(t => t.transactionHash === 'recvtx1')!;
+    expect(tx.status).toBe('CONFIRMED');
+    expect(tx.type).toBe('RECEIVE');
+  });
 });


### PR DESCRIPTION
Current scan frequency is clamp by chrome due to hi-frequency. We fix the scan-cadence (backfill 0.1→1 min), kicks a scan when the popup opens. Also inserts optimistic PENDING entry on send so the activity list updates instantly, and coalesces concurrent scans in scanManager.