### PR TITLE
Fix: reject non-http origins and sanitize bidi controls in approval popup [CHUI-AUDIT-012]

### DIFF
--- a/chrome-extension/src/background/messaging/rpc.ts
+++ b/chrome-extension/src/background/messaging/rpc.ts
@@ -154,7 +154,11 @@ export async function handle(message: ProviderRpc, sender: Runtime.MessageSender
     const fn = handlers[rpcRequest.method];
     if (!fn) return rpcErrorResponse(rpcRequest.id, -32601, `Method not found: ${rpcRequest.method}`);
 
-    const approved = await requestUserApproval(originFromSender(sender), rpcRequest);
+    const origin = originFromSender(sender);
+    if (origin === 'unknown') {
+      return rpcErrorResponse(rpcRequest.id, 4001, 'Request from non-web origin rejected');
+    }
+    const approved = await requestUserApproval(origin, rpcRequest);
     if (!approved) {
       return rpcErrorResponse(rpcRequest.id, 4001, 'User rejected the request');
     }

--- a/chrome-extension/src/background/messaging/rpc.ts
+++ b/chrome-extension/src/background/messaging/rpc.ts
@@ -172,16 +172,16 @@ export async function handle(message: ProviderRpc, sender: Runtime.MessageSender
 }
 
 // Bidi control codepoints that can visually reorder text to spoof domains.
-const BIDI_CONTROLS = /[‎‏‪-‮⁦-⁩]/g;
+const BIDI_CONTROLS = /[‎‏‪-‮⁦-⁩]/;
 
 function originFromSender(sender: Runtime.MessageSender): string {
   if (!sender.url) return 'unknown';
   try {
     const parsed = new URL(sender.url);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return 'unknown';
-    const hostname = parsed.hostname.replace(BIDI_CONTROLS, '');
-    // Reject empty or non-ASCII hostnames (IDN should already be punycode via WHATWG URL parsing).
-    if (!hostname || /[^\x00-\x7F]/.test(hostname)) return 'unknown';
+    const hostname = parsed.hostname;
+    // Reject empty, bidi-containing, or non-ASCII hostnames (IDN already punycode via WHATWG URL).
+    if (!hostname || BIDI_CONTROLS.test(hostname) || /[^ -~]/.test(hostname)) return 'unknown';
     const port = parsed.port ? `:${parsed.port}` : '';
     return `${parsed.protocol}//${hostname}${port}`;
   } catch {

--- a/chrome-extension/src/background/messaging/rpc.ts
+++ b/chrome-extension/src/background/messaging/rpc.ts
@@ -165,10 +165,19 @@ export async function handle(message: ProviderRpc, sender: Runtime.MessageSender
   }
 }
 
+// Bidi control codepoints that can visually reorder text to spoof domains.
+const BIDI_CONTROLS = /[‎‏‪-‮⁦-⁩]/g;
+
 function originFromSender(sender: Runtime.MessageSender): string {
   if (!sender.url) return 'unknown';
   try {
-    return new URL(sender.url).origin;
+    const parsed = new URL(sender.url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return 'unknown';
+    const hostname = parsed.hostname.replace(BIDI_CONTROLS, '');
+    // Reject empty or non-ASCII hostnames (IDN should already be punycode via WHATWG URL parsing).
+    if (!hostname || /[^\x00-\x7F]/.test(hostname)) return 'unknown';
+    const port = parsed.port ? `:${parsed.port}` : '';
+    return `${parsed.protocol}//${hostname}${port}`;
   } catch {
     return 'unknown';
   }

--- a/pages/popup/src/pages/provider/Approval.tsx
+++ b/pages/popup/src/pages/provider/Approval.tsx
@@ -97,7 +97,9 @@ export const ProviderApproval: React.FC = () => {
       <div className="mt-6">
         <div className="text-sm text-white mb-6">
           <div className="font-medium text-white mb-1">Website</div>
-          <div className="break-all font-bold">{origin}</div>
+          <div className="break-all font-bold">
+            <bdi dir="ltr">{origin}</bdi>
+          </div>
         </div>
 
         <div className="text-sm text-white mb-6">

--- a/pages/popup/src/pages/provider/Approval.tsx
+++ b/pages/popup/src/pages/provider/Approval.tsx
@@ -76,6 +76,7 @@ export const ProviderApproval: React.FC = () => {
 
   const { origin, rpc } = approval;
   const methodDescription = METHOD_COPY[rpc.method];
+  const isUnknownOrigin = origin === 'unknown';
 
   return (
     <div className="flex flex-col justify-start items-start text-white bg-dark h-[600px] px-4 pt-12">
@@ -100,6 +101,11 @@ export const ProviderApproval: React.FC = () => {
           <div className="break-all font-bold">
             <bdi dir="ltr">{origin}</bdi>
           </div>
+          {isUnknownOrigin && (
+            <div className="mt-1 text-xs text-red-400">
+              Request from an unverified or non-web origin. Approval is blocked.
+            </div>
+          )}
         </div>
 
         <div className="text-sm text-white mb-6">
@@ -114,7 +120,7 @@ export const ProviderApproval: React.FC = () => {
         <Button className="flex justify-center gap-2 w-full bg-opacity-0 text-white" onClick={handleReject}>
           Reject
         </Button>
-        <Button className="flex justify-center gap-2 w-full" onClick={handleApprove}>
+        <Button className="flex justify-center gap-2 w-full" onClick={handleApprove} disabled={isUnknownOrigin}>
           Approve
         </Button>
       </div>


### PR DESCRIPTION
### BDI

<img width="1141" height="630" alt="image" src="https://github.com/user-attachments/assets/8b487d00-2e98-453e-a965-22afd062e60b" />

