### PR TITLE
Fix: prevent seed overwrite on SW restart and direct route navigation [CHUI-AUDIT-010]

### DIFF
--- a/packages/backend/src/modules/wallet.ts
+++ b/packages/backend/src/modules/wallet.ts
@@ -81,8 +81,8 @@ export class Wallet {
    * @throws {Error} If a wallet already exists, no valid key is provided, or the mnemonic is invalid.
    */
   public async create(options: CreateWalletOptions): Promise<void> {
-    if (this.root) {
-      throw new Error('Wallet already exist');
+    if (this.encryptedVault !== null) {
+      throw new Error('WALLET_ALREADY_EXISTS');
     }
 
     this.network = options.network === Network.Testnet ? bitcoin.networks.testnet : bitcoin.networks.bitcoin;

--- a/packages/backend/tests/modules/wallet.test.ts
+++ b/packages/backend/tests/modules/wallet.test.ts
@@ -42,13 +42,35 @@ describe('Wallet — creation & restoration', () => {
     ).rejects.toThrow('Invalid mnemonic');
   });
 
-  it('throws "Wallet already exist" on second create()', async () => {
+  it('throws WALLET_ALREADY_EXISTS on second create() with the same instance', async () => {
     const w = new Wallet();
     await w.init();
     await w.create({ password: PASSWORD, network: Network.Mainnet, mnemonic: MNEMONIC });
     await expect(w.create({ password: PASSWORD, network: Network.Mainnet, mnemonic: MNEMONIC })).rejects.toThrow(
-      'Wallet already exist',
+      'WALLET_ALREADY_EXISTS',
     );
+  });
+
+  it('throws WALLET_ALREADY_EXISTS on create() after SW restart (root is null but vault is on disk)', async () => {
+    // Simulate initial wallet creation
+    const first = new Wallet();
+    await first.init();
+    await first.create({ password: PASSWORD, network: Network.Mainnet, mnemonic: MNEMONIC });
+    const originalMnemonic = await first.getMnemonic(PASSWORD);
+
+    // Simulate SW restart: new instance loads encryptedVault from storage but root is null
+    const restarted = new Wallet();
+    await restarted.init();
+    expect(restarted.root).toBeNull();
+    expect(restarted.isRestorable()).toBe(true);
+
+    await expect(restarted.create({ password: PASSWORD, network: Network.Mainnet })).rejects.toThrow(
+      'WALLET_ALREADY_EXISTS',
+    );
+
+    // Vault must be unchanged — original mnemonic still decryptable
+    await restarted.restore(Network.Mainnet, PASSWORD);
+    expect(await restarted.getMnemonic(PASSWORD)).toBe(originalMnemonic);
   });
 
   it('persists encrypted vault to chrome.storage.local under "wallet"', async () => {

--- a/pages/popup/src/app/App.tsx
+++ b/pages/popup/src/app/App.tsx
@@ -87,7 +87,14 @@ export const App: React.FC = () => {
         <Route path="/onboard/choose-method" element={<ChooseMethod />} />
         <Route path="/onboard/restore-seed" element={<RestoreSeed />} />
         <Route path="/onboard/generate-seed" element={<GenerateSeed />} />
-        <Route path="/onboard/backup-seed" element={<BackupSeed />} />
+        <Route
+          path="/onboard/backup-seed"
+          element={
+            <RequireUnlocked>
+              <BackupSeed />
+            </RequireUnlocked>
+          }
+        />
         <Route path="/onboard/verify-seed" element={<VerifySeed />} />
         <Route path="/onboard/complete" element={<Complete />} />
         <Route path="/dashboard" element={<Dashboard />} />

--- a/pages/popup/src/pages/onboarding/BackupSeed.tsx
+++ b/pages/popup/src/pages/onboarding/BackupSeed.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import { SeedColumn } from '@src/components/SeedColumn';
 import { Button } from '@src/components/Button';
 import { sendMessage } from '@src/utils/bridge';
-import { getSessionPassword } from '@extension/backend/src/utils/sessionStorageHelper';
 
 export const BackupSeed: React.FC = () => {
   const navigate = useNavigate();
@@ -15,8 +14,6 @@ export const BackupSeed: React.FC = () => {
   useEffect(() => {
     (async () => {
       try {
-        const password = await getSessionPassword();
-        await sendMessage('wallet.create', { password });
         const seed: string = await sendMessage('wallet.getMnemonic');
         if (!seed) {
           console.error('Failed to recover seed');

--- a/pages/popup/src/pages/onboarding/GenerateSeed.tsx
+++ b/pages/popup/src/pages/onboarding/GenerateSeed.tsx
@@ -1,10 +1,36 @@
 import type * as React from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@src/components/Button';
+import { sendMessage } from '@src/utils/bridge';
+import { getSessionPassword } from '@extension/backend/src/utils/sessionStorageHelper';
+import { useWalletContext } from '@src/context/WalletContext';
 
 export const GenerateSeed: React.FC = () => {
   const navigate = useNavigate();
+  const { init } = useWalletContext();
+  const [error, setError] = useState<string | null>(null);
   const infoLines = ['Back up your wallet.', 'Never lose it.', 'Never share it with anyone.'];
+
+  const handleReveal = async () => {
+    try {
+      setError(null);
+      const password = await getSessionPassword();
+      if (!password) {
+        setError('Password not found. Please go back and set a password.');
+        return;
+      }
+      try {
+        await sendMessage('wallet.create', { password });
+      } catch (createErr) {
+        if (!String(createErr).includes('WALLET_ALREADY_EXISTS')) throw createErr;
+      }
+      await init();
+      navigate('/onboard/backup-seed');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create wallet');
+    }
+  };
 
   return (
     <div className="flex h-full w-full overflow-hidden flex-col px-5 pb-[19px] bg-dark">
@@ -32,8 +58,9 @@ export const GenerateSeed: React.FC = () => {
               <li key={index}>{line}</li>
             ))}
           </ul>
+          {error && <p className="mt-4 text-sm text-primary-red">{error}</p>}
         </div>
-        <Button className="absolute w-full bottom-[19px]" onClick={() => navigate('/onboard/backup-seed')}>
+        <Button className="absolute w-full bottom-[19px]" onClick={handleReveal}>
           Reveal seed phrase
         </Button>
       </div>


### PR DESCRIPTION
That screen is SetPassword.tsx's internal choose-method step. GenerateSeed route (/onboard/generate-seed) is orphaned — nothing in the current UI navigates there. Same for BackupSeed (/onboard/backup-seed) — unreachable via normal flow.

The actual new-wallet path is:


SetPassword → "Create new wallet" → wallet.create → /onboard/complete
BackupSeed is a dead route. Our fix to GenerateSeed.tsx is on dead code.

Either way, the fix has been added and a two new unit tests checks the exploit. 