### PR TITLE
Tighten chrome.storage call sites for @types/chrome >= 0.1

### DIFF
--- a/packages/backend/src/accountManager.ts
+++ b/packages/backend/src/accountManager.ts
@@ -57,9 +57,7 @@ export class AccountManager {
    * @private load all accounts from chrome.storage.local
    */
   private async load() {
-    const payload = await new Promise<{ [key: string]: Account[] | undefined }>(resolve => {
-      chrome.storage.local.get(ACCOUNTS_KEY, resolve);
-    });
+    const payload = (await chrome.storage.local.get(ACCOUNTS_KEY)) as { [key: string]: Account[] | undefined };
     const stored = payload[ACCOUNTS_KEY] ?? [];
     const deduped: Account[] = [];
     const seen = new Set<string>();
@@ -79,9 +77,7 @@ export class AccountManager {
    * @private persist all accounts to chrome.storage.local
    */
   private async save() {
-    await new Promise<void>(resolve => {
-      chrome.storage.local.set({ [ACCOUNTS_KEY]: this.accounts }, () => resolve());
-    });
+    await chrome.storage.local.set({ [ACCOUNTS_KEY]: this.accounts });
   }
 
   public async destroy(): Promise<void> {

--- a/packages/backend/src/modules/wallet.ts
+++ b/packages/backend/src/modules/wallet.ts
@@ -304,10 +304,7 @@ export class Wallet {
    * @private
    */
   private async load(): Promise<void> {
-    const payload = await new Promise<{ [key: string]: WalletMeta | undefined }>(resolve => {
-      chrome.storage.local.get(WALLET_KEY, resolve);
-    });
-
+    const payload = (await chrome.storage.local.get(WALLET_KEY)) as { [key: string]: WalletMeta | undefined };
     const wallet = payload[WALLET_KEY] ?? null;
     if (wallet) {
       this.encryptedVault = wallet.vault;
@@ -320,18 +317,8 @@ export class Wallet {
    * @private
    */
   private async save(): Promise<void> {
-    await new Promise<void>(resolve => {
-      const wallet: WalletMeta = {
-        vault: this.encryptedVault,
-      };
-
-      chrome.storage.local.set(
-        {
-          [WALLET_KEY]: wallet,
-        },
-        () => resolve(),
-      );
-    });
+    const wallet: WalletMeta = { vault: this.encryptedVault };
+    await chrome.storage.local.set({ [WALLET_KEY]: wallet });
   }
 
   /**

--- a/packages/backend/src/utils/sessionStorageHelper.ts
+++ b/packages/backend/src/utils/sessionStorageHelper.ts
@@ -9,9 +9,11 @@ export async function setSessionPassword(pwd: string): Promise<void> {
   await chrome.storage.session.set({ [SESSION_PASSWORD_KEY]: data });
 }
 
+type SessionPasswordEntry = { value: string; expiry: number };
+
 export async function getSessionPassword(): Promise<string | null> {
   const result = await chrome.storage.session.get([SESSION_PASSWORD_KEY]);
-  const data = result[SESSION_PASSWORD_KEY];
+  const data = result[SESSION_PASSWORD_KEY] as SessionPasswordEntry | undefined;
   if (!data) return null;
   if (Date.now() > data.expiry) {
     await chrome.storage.session.remove([SESSION_PASSWORD_KEY]);

--- a/packages/storage/lib/base/types.ts
+++ b/packages/storage/lib/base/types.ts
@@ -38,8 +38,8 @@ export type StorageConfig<D = string> = {
      */
     serialize: (value: D) => string;
     /**
-     * convert string value from storage to non-native values
+     * convert raw value from storage; storage returns unknown at runtime
      */
-    deserialize: (text: string) => D;
+    deserialize: (value: unknown) => D;
   };
 };


### PR DESCRIPTION
Unblocks the @types/chrome upgrade in #121.

- `packages/storage/lib/base/types.ts`: `deserialize` signature widened from `(text: string) => D` to `(value: unknown) => D`. Storage values are runtime-untyped; `string` was the wrong contract.
- `packages/backend/src/utils/sessionStorageHelper.ts`: typed the session-password entry at the read site instead of relying on implicit `any`.
- `packages/backend/src/modules/wallet.ts` and `packages/backend/src/accountManager.ts`: replaced legacy `new Promise(resolve => chrome.storage.local.get/set(..., resolve))` wrappers with the native Promise API.

Verified compile + tests with both `@types/chrome@0.0.270` (current) and `@types/chrome@0.1.42` (#121 target).