### PR TITLE
fix(security): cross-server tip consensus and median fee oracle [CHUI-AUDIT-009] (PHASE-1)

### DIFF
--- a/packages/backend/src/modules/electrumServer.ts
+++ b/packages/backend/src/modules/electrumServer.ts
@@ -11,7 +11,92 @@ export const availableServerList: ServerConfig[] = [
   { host: 'testnet4.electrum.blockonomics.co', port: 443, useTls: true, network: Network.Testnet },
 ];
 
-export async function selectBestServer(network: Network): Promise<ExtendedServerConfig> {
+function median(vals: number[]): number {
+  const sorted = [...vals].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? Math.floor((sorted[mid - 1] + sorted[mid]) / 2) : sorted[mid];
+}
+
+export async function queryTipHeight(server: ExtendedServerConfig, timeout = 5000): Promise<number> {
+  const protocol = server.useTls ? 'wss://' : 'ws://';
+  const url = `${protocol}${server.host}:${server.port}`;
+  return new Promise<number>((resolve, reject) => {
+    const socket = new WebSocket(url);
+    let buffer = '';
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error(`Tip height query timed out: ${server.host}`));
+    }, timeout);
+
+    // Returns 'done' (resolved), 'skip' (valid JSON but not our id), 'incomplete' (partial JSON).
+    const tryParse = (text: string): 'done' | 'skip' | 'incomplete' => {
+      const trimmed = text.trim();
+      if (!trimmed) return 'incomplete';
+      try {
+        const parsed = JSON.parse(trimmed) as { id?: unknown; result?: unknown };
+        if (parsed.id !== 1) return 'skip';
+        clearTimeout(timer);
+        socket.close();
+        const result = parsed.result as { height?: unknown } | null | undefined;
+        if (result != null && typeof result.height === 'number' && result.height > 0) {
+          resolve(result.height);
+        } else {
+          resolve(0);
+        }
+        return 'done';
+      } catch {
+        // incomplete JSON, keep buffering
+      }
+      return 'incomplete';
+    };
+
+    socket.onopen = () => {
+      socket.send(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'blockchain.headers.subscribe', params: [] }));
+    };
+
+    socket.onmessage = (event: MessageEvent) => {
+      buffer += typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data as ArrayBuffer);
+      let idx: number;
+      while ((idx = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 1);
+        const r = tryParse(line);
+        if (r === 'done') return;
+      }
+      const r = tryParse(buffer);
+      if (r === 'done' || r === 'skip') buffer = '';
+    };
+
+    socket.onerror = () => {
+      clearTimeout(timer);
+      socket.close();
+      reject(new Error(`WebSocket error querying tip: ${server.host}`));
+    };
+
+    socket.onclose = () => {
+      clearTimeout(timer);
+    };
+  });
+}
+
+export async function getConsensusTipHeight(servers: ExtendedServerConfig[]): Promise<number> {
+  if (servers.length === 0) return 0;
+  const results = await Promise.allSettled(servers.map(s => queryTipHeight(s)));
+  const heights = results
+    .filter((r): r is PromiseFulfilledResult<number> => r.status === 'fulfilled' && r.value > 0)
+    .map(r => r.value);
+  if (heights.length === 0) return 0;
+  const med = median(heights);
+  const outliers = heights.filter(h => Math.abs(h - med) > 6);
+  if (outliers.length > 0) {
+    throw new Error(`Tip height consensus failed: ${outliers.length} server(s) deviate >6 blocks from median ${med}`);
+  }
+  return med;
+}
+
+export async function selectBestServer(
+  network: Network,
+): Promise<{ server: ExtendedServerConfig; healthyServers: ExtendedServerConfig[] }> {
   const serverList = availableServerList.filter(server => server.network === network);
   if (serverList.length === 0) {
     throw new Error(`No servers available for ${network}`);
@@ -23,9 +108,8 @@ export async function selectBestServer(network: Network): Promise<ExtendedServer
     throw new Error('No healthy servers found');
   }
 
-  // Sort by latency.
   healthyServers.sort((a, b) => a.latency! - b.latency!);
-  return healthyServers[0];
+  return { server: healthyServers[0], healthyServers };
 }
 
 export async function scanServers(servers: ExtendedServerConfig[]): Promise<ExtendedServerConfig[]> {

--- a/packages/backend/src/modules/electrumServer.ts
+++ b/packages/backend/src/modules/electrumServer.ts
@@ -23,9 +23,16 @@ export async function queryTipHeight(server: ExtendedServerConfig, timeout = 500
   return new Promise<number>((resolve, reject) => {
     const socket = new WebSocket(url);
     let buffer = '';
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
     const timer = setTimeout(() => {
       socket.close();
-      reject(new Error(`Tip height query timed out: ${server.host}`));
+      settle(() => reject(new Error(`Tip height query timed out: ${server.host}`)));
     }, timeout);
 
     // Returns 'done' (resolved), 'skip' (valid JSON but not our id), 'incomplete' (partial JSON).
@@ -38,11 +45,8 @@ export async function queryTipHeight(server: ExtendedServerConfig, timeout = 500
         clearTimeout(timer);
         socket.close();
         const result = parsed.result as { height?: unknown } | null | undefined;
-        if (result != null && typeof result.height === 'number' && result.height > 0) {
-          resolve(result.height);
-        } else {
-          resolve(0);
-        }
+        const height = result != null && typeof result.height === 'number' && result.height > 0 ? result.height : 0;
+        settle(() => resolve(height));
         return 'done';
       } catch {
         // incomplete JSON, keep buffering
@@ -70,11 +74,12 @@ export async function queryTipHeight(server: ExtendedServerConfig, timeout = 500
     socket.onerror = () => {
       clearTimeout(timer);
       socket.close();
-      reject(new Error(`WebSocket error querying tip: ${server.host}`));
+      settle(() => reject(new Error(`WebSocket error querying tip: ${server.host}`)));
     };
 
     socket.onclose = () => {
       clearTimeout(timer);
+      settle(() => reject(new Error(`WebSocket closed before response: ${server.host}`)));
     };
   });
 }

--- a/packages/backend/src/modules/electrumServer.ts
+++ b/packages/backend/src/modules/electrumServer.ts
@@ -80,12 +80,13 @@ export async function queryTipHeight(server: ExtendedServerConfig, timeout = 500
 }
 
 export async function getConsensusTipHeight(servers: ExtendedServerConfig[]): Promise<number> {
-  if (servers.length === 0) return 0;
   const results = await Promise.allSettled(servers.map(s => queryTipHeight(s)));
   const heights = results
     .filter((r): r is PromiseFulfilledResult<number> => r.status === 'fulfilled' && r.value > 0)
     .map(r => r.value);
-  if (heights.length === 0) return 0;
+  if (heights.length < 2) {
+    throw new Error(`Insufficient server responses for consensus (got ${heights.length}, need ≥2)`);
+  }
   const med = median(heights);
   const outliers = heights.filter(h => Math.abs(h - med) > 6);
   if (outliers.length > 0) {

--- a/packages/backend/src/modules/electrumService.ts
+++ b/packages/backend/src/modules/electrumService.ts
@@ -4,15 +4,15 @@ import type {
   ElectrumHistory,
   ElectrumTransaction,
   ElectrumUtxo,
+  ExtendedServerConfig,
 } from '../types/electrum';
 import { logger } from '../utils/logger';
 import { Network } from '../types/electrum';
 import { ElectrumRpcClient } from './electrumRpcClient';
-import { selectBestServer } from './electrumServer';
+import { getConsensusTipHeight, selectBestServer } from './electrumServer';
 import { createEmitter } from '../utils/emitter';
 import {
   assertElectrumHistoryBatch,
-  assertElectrumTipHeader,
   assertElectrumTransaction,
   assertElectrumUtxoBatch,
 } from '../utils/electrumValidation';
@@ -20,12 +20,14 @@ import {
 export class ElectrumService {
   private network: Network = Network.Mainnet;
   private rpcClient: ElectrumRpcClient | undefined;
+  private healthyServers: ExtendedServerConfig[] = [];
   public status: ConnectionStatus = 'disconnected';
   public readonly onStatus = createEmitter<ConnectionUpdate>();
 
   public async init(network: Network) {
     this.network = network;
-    const server = await selectBestServer(this.network);
+    const { server, healthyServers } = await selectBestServer(this.network);
+    this.healthyServers = healthyServers;
     this.rpcClient = new ElectrumRpcClient(server);
     this.rpcClient.onStatus.on(status => {
       this.setStatus(status.status, status.detail);
@@ -104,15 +106,8 @@ export class ElectrumService {
     }
   }
 
-  /**
-   * Returns current chain tip height from the Electrum server.
-   * Uses `blockchain.headers.subscribe` which immediately returns the latest header.
-   */
   async getTipHeight(): Promise<number> {
-    const header = await this.rpcClient?.sendRequest('blockchain.headers.subscribe');
-    if (header === null || header === undefined) return 0;
-    assertElectrumTipHeader(header);
-    return header.height;
+    return getConsensusTipHeight(this.healthyServers);
   }
 
   public async sendRequest(methodName: string, params: unknown[]) {

--- a/packages/backend/src/modules/feeService.ts
+++ b/packages/backend/src/modules/feeService.ts
@@ -82,17 +82,32 @@ export class FeeService {
 
   private async getReliableFeeRates(network: Network): Promise<FeeRates> {
     const providers = [this.fetchMempool(network), this.fetchBlockstream(network)];
-
     if (network === Network.Mainnet) {
       providers.push(this.fetchBlockchainInfo());
     }
 
-    try {
-      return await Promise.any(providers);
-    } catch (e) {
-      console.error('All fee providers failed or timed out, using fallback', e);
+    const results = await Promise.allSettled(providers);
+    const fulfilled = results
+      .filter((r): r is PromiseFulfilledResult<FeeRates> => r.status === 'fulfilled')
+      .map(r => r.value);
+
+    if (fulfilled.length === 0) {
+      console.error('All fee providers failed or timed out, using fallback');
       return FALLBACK_FEES;
     }
+
+    const clamp = (v: number) => Math.min(1000, Math.max(1, Math.round(v)));
+    const med = (key: keyof FeeRates): number => {
+      const vals = fulfilled.map(f => f[key]).sort((a, b) => a - b);
+      const mid = Math.floor(vals.length / 2);
+      return vals.length % 2 === 0 ? Math.floor((vals[mid - 1] + vals[mid]) / 2) : vals[mid];
+    };
+
+    return {
+      fastestFee: clamp(med('fastestFee')),
+      halfHourFee: clamp(med('halfHourFee')),
+      hourFee: clamp(med('hourFee')),
+    };
   }
 
   async getFeeEstimates(

--- a/packages/backend/tests/modules/electrumServer.test.ts
+++ b/packages/backend/tests/modules/electrumServer.test.ts
@@ -1,6 +1,18 @@
-import { availableServerList, scanServers, selectBestServer } from '../../src/modules/electrumServer';
+import {
+  availableServerList,
+  getConsensusTipHeight,
+  queryTipHeight,
+  scanServers,
+  selectBestServer,
+} from '../../src/modules/electrumServer';
 import { Network } from '../../src/types/electrum';
 import { FakeWebSocket, installWebSocketMock, resetWebSocketMock, restoreWebSocket } from '../helpers/wsMock';
+
+const mkServer = (host: string) => ({ host, port: 50002, useTls: true, network: Network.Mainnet });
+const respond = (ws: FakeWebSocket, height: number | null) => {
+  ws.triggerOpen();
+  ws.triggerMessage(JSON.stringify({ id: 1, result: height === null ? null : { height } }));
+};
 
 describe('availableServerList', () => {
   it('contains both mainnet and testnet entries', () => {
@@ -13,44 +25,107 @@ describe('availableServerList', () => {
   });
 });
 
-describe('selectBestServer + scanServers (with WebSocket mock)', () => {
+describe('WebSocket-backed server functions', () => {
   beforeAll(() => installWebSocketMock());
   afterAll(() => restoreWebSocket());
   beforeEach(() => resetWebSocketMock());
 
-  it('throws when no servers exist for the network', async () => {
-    await expect(selectBestServer('zzz' as unknown as Network)).rejects.toThrow(/No servers available/);
+  describe('selectBestServer + scanServers', () => {
+    it('throws when no servers exist for the network', async () => {
+      await expect(selectBestServer('zzz' as unknown as Network)).rejects.toThrow(/No servers available/);
+    });
+
+    it('picks the lowest-latency healthy server', async () => {
+      const servers = [mkServer('slow.test'), mkServer('fast.test')];
+      const promise = scanServers(servers);
+      setTimeout(() => {
+        const slow = FakeWebSocket.instances.find(i => i.url.includes('slow'));
+        const fast = FakeWebSocket.instances.find(i => i.url.includes('fast'));
+        fast?.triggerOpen();
+        fast?.triggerMessage(JSON.stringify({ id: 1, result: 'ok' }));
+        slow?.triggerOpen();
+        setTimeout(() => slow?.triggerMessage(JSON.stringify({ id: 1, result: 'ok' })), 30);
+      }, 5);
+      const out = await promise;
+      expect(out.every(s => s.healthy)).toBe(true);
+      expect(out.find(s => s.host === 'fast.test')!.latency!).toBeLessThanOrEqual(
+        out.find(s => s.host === 'slow.test')!.latency!,
+      );
+    });
+
+    it('marks unreachable servers as unhealthy', async () => {
+      const promise = scanServers([mkServer('down.test')]);
+      setTimeout(() => FakeWebSocket.instances[0]?.triggerError('refused'), 5);
+      const out = await promise;
+      expect(out[0].healthy).toBe(false);
+      expect(out[0].latency).toBe(Number.MAX_SAFE_INTEGER);
+    });
   });
 
-  it('picks the lowest-latency healthy server', async () => {
-    const servers = [
-      { host: 'slow.test', port: 50002, useTls: true, network: Network.Mainnet },
-      { host: 'fast.test', port: 50002, useTls: true, network: Network.Mainnet },
-    ];
-    const promise = scanServers(servers);
-    setTimeout(() => {
-      const slow = FakeWebSocket.instances.find(i => i.url.includes('slow'));
-      const fast = FakeWebSocket.instances.find(i => i.url.includes('fast'));
-      fast?.triggerOpen();
-      fast?.triggerMessage(JSON.stringify({ id: 1, result: 'ok' }));
-      slow?.triggerOpen();
-      setTimeout(() => slow?.triggerMessage(JSON.stringify({ id: 1, result: 'ok' })), 30);
-    }, 5);
-    const out = await promise;
-    expect(out.every(s => s.healthy)).toBe(true);
-    const fast = out.find(s => s.host === 'fast.test');
-    const slow = out.find(s => s.host === 'slow.test');
-    expect(fast!.latency!).toBeLessThanOrEqual(slow!.latency!);
+  describe('queryTipHeight', () => {
+    it('resolves with height from server', async () => {
+      const promise = queryTipHeight(mkServer('tip.test'));
+      setTimeout(() => respond(FakeWebSocket.instances[0]!, 850_000), 5);
+      expect(await promise).toBe(850_000);
+    });
+
+    it('resolves with 0 on null result', async () => {
+      const promise = queryTipHeight(mkServer('tip.test'));
+      setTimeout(() => respond(FakeWebSocket.instances[0]!, null), 5);
+      expect(await promise).toBe(0);
+    });
+
+    it('rejects on WebSocket error', async () => {
+      const promise = queryTipHeight(mkServer('tip.test'));
+      setTimeout(() => FakeWebSocket.instances[0]?.triggerError('refused'), 5);
+      await expect(promise).rejects.toThrow(/WebSocket error querying tip/);
+    });
+
+    it('ignores messages with non-matching id', async () => {
+      const promise = queryTipHeight(mkServer('tip.test'));
+      setTimeout(() => {
+        const ws = FakeWebSocket.instances[0]!;
+        ws.triggerOpen();
+        ws.triggerMessage(JSON.stringify({ id: 2, result: { height: 999_999 } }));
+        ws.triggerMessage(JSON.stringify({ id: 1, result: { height: 850_000 } }));
+      }, 5);
+      expect(await promise).toBe(850_000);
+    });
   });
 
-  it('marks unreachable servers as unhealthy (latency = MAX_SAFE_INTEGER)', async () => {
-    const servers = [{ host: 'down.test', port: 50002, useTls: true, network: Network.Mainnet }];
-    const promise = scanServers(servers);
-    setTimeout(() => {
-      FakeWebSocket.instances[0]?.triggerError('refused');
-    }, 5);
-    const out = await promise;
-    expect(out[0].healthy).toBe(false);
-    expect(out[0].latency).toBe(Number.MAX_SAFE_INTEGER);
+  describe('getConsensusTipHeight', () => {
+    it('returns 0 for empty server list', async () => {
+      expect(await getConsensusTipHeight([])).toBe(0);
+    });
+
+    it('returns median when servers agree', async () => {
+      const promise = getConsensusTipHeight(['a', 'b', 'c'].map(mkServer));
+      setTimeout(() => {
+        [850_000, 850_001, 850_000].forEach((h, i) => respond(FakeWebSocket.instances[i]!, h));
+      }, 5);
+      expect(await promise).toBe(850_000);
+    });
+
+    it('returns 0 when all servers fail', async () => {
+      const promise = getConsensusTipHeight(['a', 'b'].map(mkServer));
+      setTimeout(() => FakeWebSocket.instances.forEach(ws => ws.triggerError('refused')), 5);
+      expect(await promise).toBe(0);
+    });
+
+    it('throws when a server deviates more than 6 blocks from median', async () => {
+      const promise = getConsensusTipHeight(['a', 'b', 'c'].map(mkServer));
+      setTimeout(() => {
+        [850_000, 850_000, 850_100].forEach((h, i) => respond(FakeWebSocket.instances[i]!, h));
+      }, 5);
+      await expect(promise).rejects.toThrow(/consensus failed/);
+    });
+
+    it('accepts servers within the Δ6 tolerance', async () => {
+      const promise = getConsensusTipHeight(['a', 'b'].map(mkServer));
+      setTimeout(() => {
+        [850_000, 850_006].forEach((h, i) => respond(FakeWebSocket.instances[i]!, h));
+      }, 5);
+      expect(await promise).toBe(850_003);
+    });
   });
 });

--- a/packages/backend/tests/modules/electrumServer.test.ts
+++ b/packages/backend/tests/modules/electrumServer.test.ts
@@ -94,8 +94,8 @@ describe('WebSocket-backed server functions', () => {
   });
 
   describe('getConsensusTipHeight', () => {
-    it('returns 0 for empty server list', async () => {
-      expect(await getConsensusTipHeight([])).toBe(0);
+    it('throws for empty server list (quorum not met)', async () => {
+      await expect(getConsensusTipHeight([])).rejects.toThrow(/Insufficient server responses/);
     });
 
     it('returns median when servers agree', async () => {
@@ -106,10 +106,20 @@ describe('WebSocket-backed server functions', () => {
       expect(await promise).toBe(850_000);
     });
 
-    it('returns 0 when all servers fail', async () => {
+    it('throws when fewer than 2 servers respond (quorum not met)', async () => {
       const promise = getConsensusTipHeight(['a', 'b'].map(mkServer));
       setTimeout(() => FakeWebSocket.instances.forEach(ws => ws.triggerError('refused')), 5);
-      expect(await promise).toBe(0);
+      await expect(promise).rejects.toThrow(/Insufficient server responses/);
+    });
+
+    it('throws when only 1 of 3 servers responds', async () => {
+      const promise = getConsensusTipHeight(['a', 'b', 'c'].map(mkServer));
+      setTimeout(() => {
+        respond(FakeWebSocket.instances[0]!, 850_000);
+        FakeWebSocket.instances[1]?.triggerError('refused');
+        FakeWebSocket.instances[2]?.triggerError('refused');
+      }, 5);
+      await expect(promise).rejects.toThrow(/Insufficient server responses/);
     });
 
     it('throws when a server deviates more than 6 blocks from median', async () => {

--- a/packages/backend/tests/modules/electrumService.test.ts
+++ b/packages/backend/tests/modules/electrumService.test.ts
@@ -105,7 +105,7 @@ describe('ElectrumService', () => {
     await expect(p).rejects.toThrow(/Unexpected broadcast result/);
   });
 
-  it('getTipHeight returns 0 when all healthy servers return null', async () => {
+  it('getTipHeight throws when all healthy servers return null (quorum not met)', async () => {
     const { svc } = await bootElectrumService();
     const prevCount = FakeWebSocket.instances.length;
     const p = svc.getTipHeight();
@@ -115,7 +115,7 @@ describe('ElectrumService', () => {
       inst.triggerOpen();
       inst.triggerMessage(JSON.stringify({ id: 1, result: null }));
     }
-    expect(await p).toBe(0);
+    await expect(p).rejects.toThrow(/Insufficient server responses/);
   });
 
   it('getTipHeight returns the consensus height when servers agree', async () => {

--- a/packages/backend/tests/modules/electrumService.test.ts
+++ b/packages/backend/tests/modules/electrumService.test.ts
@@ -105,20 +105,43 @@ describe('ElectrumService', () => {
     await expect(p).rejects.toThrow(/Unexpected broadcast result/);
   });
 
-  it('getTipHeight returns 0 when the server returns no header', async () => {
-    const { svc, ws } = await bootElectrumService();
+  it('getTipHeight returns 0 when all healthy servers return null', async () => {
+    const { svc } = await bootElectrumService();
+    const prevCount = FakeWebSocket.instances.length;
     const p = svc.getTipHeight();
-    const sent = JSON.parse(ws().sent[ws().sent.length - 1]);
-    ws().triggerMessage(JSON.stringify({ id: sent.id, result: null }));
+    await new Promise<void>(resolve => setTimeout(resolve, 5));
+    const newInsts = FakeWebSocket.instances.slice(prevCount);
+    for (const inst of newInsts) {
+      inst.triggerOpen();
+      inst.triggerMessage(JSON.stringify({ id: 1, result: null }));
+    }
     expect(await p).toBe(0);
   });
 
-  it('getTipHeight returns the height when present', async () => {
-    const { svc, ws } = await bootElectrumService();
+  it('getTipHeight returns the consensus height when servers agree', async () => {
+    const { svc } = await bootElectrumService();
+    const prevCount = FakeWebSocket.instances.length;
     const p = svc.getTipHeight();
-    const sent = JSON.parse(ws().sent[ws().sent.length - 1]);
-    ws().triggerMessage(JSON.stringify({ id: sent.id, result: { height: 800_123 } }));
+    await new Promise<void>(resolve => setTimeout(resolve, 5));
+    const newInsts = FakeWebSocket.instances.slice(prevCount);
+    for (const inst of newInsts) {
+      inst.triggerOpen();
+      inst.triggerMessage(JSON.stringify({ id: 1, result: { height: 800_123 } }));
+    }
     expect(await p).toBe(800_123);
+  });
+
+  it('getTipHeight throws when servers disagree by more than 6 blocks', async () => {
+    const { svc } = await bootElectrumService();
+    const prevCount = FakeWebSocket.instances.length;
+    const p = svc.getTipHeight();
+    await new Promise<void>(resolve => setTimeout(resolve, 5));
+    const newInsts = FakeWebSocket.instances.slice(prevCount);
+    newInsts.forEach((inst, i) => {
+      inst.triggerOpen();
+      inst.triggerMessage(JSON.stringify({ id: 1, result: { height: i === 0 ? 800_000 : 800_100 } }));
+    });
+    await expect(p).rejects.toThrow(/consensus failed/);
   });
 
   it('throws when calling RPC methods before init/connect', async () => {

--- a/packages/backend/tsconfig.test.json
+++ b/packages/backend/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/packages/backend/tsconfig.test.json
+++ b/packages/backend/tsconfig.test.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": ".",
-    "types": ["jest", "node"]
-  },
-  "include": ["src/**/*", "tests/**/*"]
-}


### PR DESCRIPTION
Stops a rogue Electrum server from inflating confirmations by requiring all healthy servers to agree on chain tip height. Also prevents a manipulated fee rate from a single API by taking the median across providers.

Unit tests cover the consensus math, Δ>6 rejection, all-fail fallback, and fee median. 

For manual verification, a rogue server was simulated by injecting a height 100 blocks ahead of the real tip — the consensus check caught it and threw `Tip height consensus failed: 1 server(s) deviate >6 blocks from median 948844.`