### PR TITLE
chore(tests): remove broken vitest script, add aggregate test task

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,8 +47,8 @@ jobs:
       - name: Type-check
         run: pnpm type-check
 
-      - name: Run backend tests
-        run: pnpm --filter @extension/backend test
+      - name: Run tests
+        run: pnpm test
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   ci:
-    name: Lint, type-check, backend tests
+    name: Lint, type-check, tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -41,5 +41,5 @@ jobs:
       - name: Type-check
         run: pnpm type-check
 
-      - name: Run backend tests
-        run: pnpm --filter @extension/backend test
+      - name: Run tests
+        run: pnpm test

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -9,7 +9,6 @@
     "clean": "pnpm clean:turbo && pnpm clean:node_modules",
     "build": "vite build",
     "dev": "cross-env __DEV__=true vite build --mode development",
-    "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "pnpm lint --fix",
     "prettier": "prettier . --write --ignore-path ../.prettierignore",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:firefox": "turbo ready && cross-env __DEV__=true __FIREFOX__=true turbo watch dev --concurrency 20",
     "e2e": "pnpm build && pnpm zip && turbo e2e",
     "e2e:firefox": "pnpm build:firefox && pnpm zip:firefox && cross-env __FIREFOX__=true turbo e2e",
+    "test": "turbo test",
     "type-check": "turbo type-check",
     "lint": "turbo lint --continue -- --fix --cache --cache-location node_modules/.cache/.eslintcache",
     "lint:check": "turbo lint --continue -- --cache --cache-location node_modules/.cache/.eslintcache",

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,9 @@
     "e2e": {
       "cache": false
     },
+    "test": {
+      "cache": false
+    },
     "type-check": {
       "cache": false
     },


### PR DESCRIPTION
- Removed `"test": "vitest run"` from `chrome-extension/package.json` (vitest not installed, no test files).
- Added root `pnpm test` (`turbo test`) and matching `test` task in `turbo.json`.
- `test.yaml` and `release.yaml` now call `pnpm test` instead of `pnpm --filter @extension/backend test`.

Note: `pnpm e2e` / `turbo e2e` is dead (no workspace implements `e2e`). Out of scope here.