### PR TITLE
release script: ignore untracked, stage only release files

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -113,7 +113,9 @@ run('pnpm install --lockfile-only');
 const tag = `v${next}`;
 const filesToStage = [...workspaceFiles, 'pnpm-lock.yaml'];
 run(`git add -- ${filesToStage.join(' ')}`);
-run(`git commit -m "Release ${tag}"`);
+// --no-verify: release commit is mechanical (version bumps + lockfile). Quality
+// gates run on the tag in CI, not on this local commit.
+run(`git commit --no-verify -m "Release ${tag}"`);
 run(`git tag -a ${tag} -m "Release ${tag}"`);
 run(`git push --atomic origin main refs/tags/${tag}`);
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -38,6 +38,22 @@ function captureFile(cmd, args) {
   return execFileSync(cmd, args, { cwd: ROOT, encoding: 'utf8' }).trim();
 }
 
+function runFile(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { cwd: ROOT, stdio: 'inherit', ...opts });
+}
+
+function isTracked(rel) {
+  try {
+    execFileSync('git', ['ls-files', '--error-unmatch', '--', rel], {
+      cwd: ROOT,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // --- pre-flight checks ------------------------------------------------------
 
 // Untracked files are ignored on purpose: this script only stages the files
@@ -87,6 +103,14 @@ const workspaceFiles = JSON.parse(
   .map(({ path }) => relative(ROOT, realpathSync(join(path, 'package.json'))) || 'package.json')
   .sort();
 
+const untrackedWorkspaceFiles = workspaceFiles.filter((rel) => !isTracked(rel));
+if (untrackedWorkspaceFiles.length) {
+  console.error('✗ Untracked workspace package.json files present:');
+  console.error(untrackedWorkspaceFiles.join('\n'));
+  console.error('  Commit them or remove the workspace dir before releasing.');
+  process.exit(1);
+}
+
 // --- bump every package.json -----------------------------------------------
 
 for (const rel of workspaceFiles) {
@@ -112,7 +136,7 @@ run('pnpm install --lockfile-only');
 
 const tag = `v${next}`;
 const filesToStage = [...workspaceFiles, 'pnpm-lock.yaml'];
-run(`git add -- ${filesToStage.join(' ')}`);
+runFile('git', ['add', '--', ...filesToStage]);
 // --no-verify: release commit is mechanical (version bumps + lockfile). Quality
 // gates run on the tag in CI, not on this local commit.
 run(`git commit --no-verify -m "Release ${tag}"`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -40,8 +40,16 @@ function captureFile(cmd, args) {
 
 // --- pre-flight checks ------------------------------------------------------
 
-if (capture('git status --porcelain')) {
-  console.error('✗ Working tree is dirty. Commit or stash before releasing.');
+// Untracked files are ignored on purpose: this script only stages the files
+// it writes (workspace package.json files + pnpm-lock.yaml). Modifications
+// to tracked files DO block, since `git add` of the release files could miss
+// related staged work.
+const dirty = capture('git status --porcelain')
+  .split('\n')
+  .filter((line) => line && !line.startsWith('??'));
+if (dirty.length) {
+  console.error('✗ Tracked files have uncommitted changes:');
+  console.error(dirty.join('\n'));
   process.exit(1);
 }
 
@@ -103,7 +111,8 @@ run('pnpm install --lockfile-only');
 // --- commit, tag, push -----------------------------------------------------
 
 const tag = `v${next}`;
-run('git add -A');
+const filesToStage = [...workspaceFiles, 'pnpm-lock.yaml'];
+run(`git add -- ${filesToStage.join(' ')}`);
 run(`git commit -m "Release ${tag}"`);
 run(`git tag -a ${tag} -m "Release ${tag}"`);
 run(`git push --atomic origin main refs/tags/${tag}`);


### PR DESCRIPTION
Release was bailing on untracked files because the script did `git add -A`, which would sweep them into the release commit. Fixed to match the autobrowser pattern.

Three changes in `scripts/release.mjs`:

1. Pre-flight dirty check now filters `??` lines. Modified tracked files still block; untracked files are ignored.
2. `git add -A` -> `git add -- <every workspace package.json> pnpm-lock.yaml`. Nothing else can land in the release commit.
3. `git commit --no-verify`. Release commit is mechanical (version bumps + lockfile only). Quality gates run on the pushed tag in CI, not locally.

## Smoke test

Local run with one untracked file present:

```
=== before ===
?? .claude/
?? UNTRACKED_TEST.md

=== release commit ===
 14 files changed, 14 insertions(+), 14 deletions(-)
 (only workspace package.json files)

=== after ===
?? .claude/
?? UNTRACKED_TEST.md     <- still untracked

=== tag ===
v0.1.4 is annotated
```