### PR TITLE
hotfix: keep wallet connection alive after switch network

### DIFF
--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -16,6 +16,33 @@ import { emitBalance, emitConnection, registerMessagePort } from '@src/backgroun
 bitcoin.initEccLib(secp256k1);
 
 let electrumReconnecting = false;
+let electrumReconnectAttempt = 0;
+let electrumReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+function scheduleElectrumReconnect() {
+  if (electrumReconnecting) return;
+  if (electrumReconnectTimer) {
+    clearTimeout(electrumReconnectTimer);
+    electrumReconnectTimer = null;
+  }
+  electrumReconnecting = true;
+  void (async () => {
+    try {
+      await electrumService.connect();
+      electrumReconnectAttempt = 0;
+    } catch (err) {
+      logger.error('Electrum reconnect failed', err);
+      const delay = Math.min(30_000, 1000 * 2 ** electrumReconnectAttempt);
+      electrumReconnectAttempt++;
+      electrumReconnectTimer = setTimeout(() => {
+        electrumReconnectTimer = null;
+        scheduleElectrumReconnect();
+      }, delay);
+    } finally {
+      electrumReconnecting = false;
+    }
+  })();
+}
 
 async function init() {
   await ensureChainAdaptersReady();
@@ -24,17 +51,16 @@ async function init() {
 
   electrumService.onStatus.on(update => {
     emitConnection(update.status, update.detail);
-    if (update.status === 'disconnected' && !electrumReconnecting && update.reason !== 'switchNetwork') {
-      electrumReconnecting = true;
-      void (async () => {
-        try {
-          await electrumService.connect();
-        } catch (err) {
-          logger.error('Electrum reconnect failed', err);
-        } finally {
-          electrumReconnecting = false;
-        }
-      })();
+    if (update.status === 'connected') {
+      electrumReconnectAttempt = 0;
+      if (electrumReconnectTimer) {
+        clearTimeout(electrumReconnectTimer);
+        electrumReconnectTimer = null;
+      }
+      return;
+    }
+    if (update.status === 'disconnected' && update.reason !== 'switchNetwork') {
+      scheduleElectrumReconnect();
     }
   });
   await electrumService.connect();

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -23,6 +23,9 @@ let electrumReconnectEpoch = 0;
 function cancelElectrumReconnect() {
   electrumReconnectEpoch++;
   electrumReconnectAttempt = 0;
+  // Release the flag immediately so a fresh disconnect can schedule a new
+  // attempt without waiting for the cancelled IIFE to drain.
+  electrumReconnecting = false;
   if (electrumReconnectTimer) {
     clearTimeout(electrumReconnectTimer);
     electrumReconnectTimer = null;
@@ -52,7 +55,9 @@ function scheduleElectrumReconnect() {
         scheduleElectrumReconnect();
       }, delay);
     } finally {
-      electrumReconnecting = false;
+      // Only the matching attempt may clear the flag — a cancelled IIFE
+      // finishing late must not stomp the fresh attempt that took over.
+      if (epoch === electrumReconnectEpoch) electrumReconnecting = false;
     }
   })();
 }

--- a/chrome-extension/src/background/index.ts
+++ b/chrome-extension/src/background/index.ts
@@ -18,6 +18,16 @@ bitcoin.initEccLib(secp256k1);
 let electrumReconnecting = false;
 let electrumReconnectAttempt = 0;
 let electrumReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let electrumReconnectEpoch = 0;
+
+function cancelElectrumReconnect() {
+  electrumReconnectEpoch++;
+  electrumReconnectAttempt = 0;
+  if (electrumReconnectTimer) {
+    clearTimeout(electrumReconnectTimer);
+    electrumReconnectTimer = null;
+  }
+}
 
 function scheduleElectrumReconnect() {
   if (electrumReconnecting) return;
@@ -25,13 +35,16 @@ function scheduleElectrumReconnect() {
     clearTimeout(electrumReconnectTimer);
     electrumReconnectTimer = null;
   }
+  const epoch = electrumReconnectEpoch;
   electrumReconnecting = true;
   void (async () => {
     try {
       await electrumService.connect();
-      electrumReconnectAttempt = 0;
+      if (epoch === electrumReconnectEpoch) electrumReconnectAttempt = 0;
     } catch (err) {
       logger.error('Electrum reconnect failed', err);
+      // Bail if this attempt was cancelled mid-flight (e.g. by switchNetwork).
+      if (epoch !== electrumReconnectEpoch) return;
       const delay = Math.min(30_000, 1000 * 2 ** electrumReconnectAttempt);
       electrumReconnectAttempt++;
       electrumReconnectTimer = setTimeout(() => {
@@ -51,15 +64,15 @@ async function init() {
 
   electrumService.onStatus.on(update => {
     emitConnection(update.status, update.detail);
-    if (update.status === 'connected') {
-      electrumReconnectAttempt = 0;
-      if (electrumReconnectTimer) {
-        clearTimeout(electrumReconnectTimer);
-        electrumReconnectTimer = null;
-      }
+    if (update.reason === 'switchNetwork') {
+      cancelElectrumReconnect();
       return;
     }
-    if (update.status === 'disconnected' && update.reason !== 'switchNetwork') {
+    if (update.status === 'connected') {
+      cancelElectrumReconnect();
+      return;
+    }
+    if (update.status === 'disconnected') {
       scheduleElectrumReconnect();
     }
   });

--- a/packages/backend/src/modules/electrumRpcClient.ts
+++ b/packages/backend/src/modules/electrumRpcClient.ts
@@ -33,6 +33,8 @@ function isJsonRpcResponse(value: unknown): value is JsonRpcResponse {
  * Todo: Improve failover switch connection
  */
 export class ElectrumRpcClient {
+  private static readonly CONNECT_TIMEOUT_MS = 10_000;
+
   private server: ServerConfig | ExtendedServerConfig;
   private socket: WebSocket | null;
   private requests: Map<number, RequestResolver> = new Map();
@@ -65,14 +67,23 @@ export class ElectrumRpcClient {
       const fail = (error: Error) => {
         if (settled) return;
         settled = true;
+        clearTimeout(timeout);
         this.disconnect();
         reject(error);
       };
+      // Browser WebSockets can sit in CONNECTING indefinitely (no onopen,
+      // onerror, or onclose ever fires). Without this timeout the background
+      // reconnect loop would wait forever and never reach the backoff path.
+      const timeout = setTimeout(() => {
+        fail(new Error(`WebSocket connection timed out: ${wsUrl}`));
+      }, ElectrumRpcClient.CONNECT_TIMEOUT_MS);
 
       this.socket = new WebSocket(wsUrl);
       this.socket.onopen = () => {
+        if (settled) return;
         opened = true;
         settled = true;
+        clearTimeout(timeout);
         logger.log(`Connected to Electrum server at ${wsUrl}`);
         this.setStatus('connected');
         resolve(this);

--- a/packages/backend/src/modules/electrumRpcClient.ts
+++ b/packages/backend/src/modules/electrumRpcClient.ts
@@ -62,25 +62,32 @@ export class ElectrumRpcClient {
       const wsUrl = `${protocol}${this.server.host}:${this.server.port}`;
       this.disconnect();
 
+      const socket = new WebSocket(wsUrl);
+      this.socket = socket;
+      // Old socket events (delayed onclose, onerror, timeout) can still fire
+      // after a reconnect or network switch has replaced this.socket. Without
+      // this guard a stale handler would close the new socket via disconnect().
+      const isCurrentSocket = () => this.socket === socket;
+
       let opened = false;
       let settled = false;
       const fail = (error: Error) => {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        this.disconnect();
+        if (isCurrentSocket()) this.disconnect();
         reject(error);
       };
       // Browser WebSockets can sit in CONNECTING indefinitely (no onopen,
       // onerror, or onclose ever fires). Without this timeout the background
       // reconnect loop would wait forever and never reach the backoff path.
       const timeout = setTimeout(() => {
+        if (!isCurrentSocket()) return;
         fail(new Error(`WebSocket connection timed out: ${wsUrl}`));
       }, ElectrumRpcClient.CONNECT_TIMEOUT_MS);
 
-      this.socket = new WebSocket(wsUrl);
-      this.socket.onopen = () => {
-        if (settled) return;
+      socket.onopen = () => {
+        if (!isCurrentSocket() || settled) return;
         opened = true;
         settled = true;
         clearTimeout(timeout);
@@ -89,12 +96,14 @@ export class ElectrumRpcClient {
         resolve(this);
       };
 
-      this.socket.onmessage = (event: MessageEvent) => {
+      socket.onmessage = (event: MessageEvent) => {
+        if (!isCurrentSocket()) return;
         const raw = typeof event.data === 'string' ? event.data : new TextDecoder().decode(event.data as ArrayBuffer);
         this.handleIncomingChunk(raw);
       };
 
-      this.socket.onerror = (error: Event) => {
+      socket.onerror = (error: Event) => {
+        if (!isCurrentSocket()) return;
         const errorMessage = 'WebSocket error: ' + ((error as ErrorEvent).message || 'Unknown error');
         logger.error(errorMessage, error);
         this.setStatus('error', errorMessage);
@@ -103,7 +112,8 @@ export class ElectrumRpcClient {
 
       // Without this, a close before onopen would leave the connect() Promise
       // pending forever, and the background reconnect loop would hang on it.
-      this.socket.onclose = () => {
+      socket.onclose = () => {
+        if (!isCurrentSocket()) return;
         this.disconnect();
         logger.warn('WebSocket closed');
         if (!opened) fail(new Error(`WebSocket closed before connection opened: ${wsUrl}`));

--- a/packages/backend/src/modules/electrumRpcClient.ts
+++ b/packages/backend/src/modules/electrumRpcClient.ts
@@ -65,8 +65,10 @@ export class ElectrumRpcClient {
       const socket = new WebSocket(wsUrl);
       this.socket = socket;
       // Old socket events (delayed onclose, onerror, timeout) can still fire
-      // after a reconnect or network switch has replaced this.socket. Without
-      // this guard a stale handler would close the new socket via disconnect().
+      // after a reconnect or network switch has replaced this.socket. Stale
+      // handlers must NOT touch shared state (don't call this.disconnect or
+      // setStatus), but they STILL have to settle this connect() promise —
+      // otherwise the background reconnect loop's await hangs forever.
       const isCurrentSocket = () => this.socket === socket;
 
       let opened = false;
@@ -75,19 +77,26 @@ export class ElectrumRpcClient {
         if (settled) return;
         settled = true;
         clearTimeout(timeout);
-        if (isCurrentSocket()) this.disconnect();
+        if (isCurrentSocket()) {
+          this.disconnect();
+        } else if (socket.readyState === WebSocket.CONNECTING || socket.readyState === WebSocket.OPEN) {
+          socket.close();
+        }
         reject(error);
       };
       // Browser WebSockets can sit in CONNECTING indefinitely (no onopen,
       // onerror, or onclose ever fires). Without this timeout the background
       // reconnect loop would wait forever and never reach the backoff path.
       const timeout = setTimeout(() => {
-        if (!isCurrentSocket()) return;
         fail(new Error(`WebSocket connection timed out: ${wsUrl}`));
       }, ElectrumRpcClient.CONNECT_TIMEOUT_MS);
 
       socket.onopen = () => {
-        if (!isCurrentSocket() || settled) return;
+        if (settled) return;
+        if (!isCurrentSocket()) {
+          fail(new Error(`WebSocket replaced before opening: ${wsUrl}`));
+          return;
+        }
         opened = true;
         settled = true;
         clearTimeout(timeout);
@@ -103,20 +112,23 @@ export class ElectrumRpcClient {
       };
 
       socket.onerror = (error: Event) => {
-        if (!isCurrentSocket()) return;
         const errorMessage = 'WebSocket error: ' + ((error as ErrorEvent).message || 'Unknown error');
-        logger.error(errorMessage, error);
-        this.setStatus('error', errorMessage);
+        if (isCurrentSocket()) {
+          logger.error(errorMessage, error);
+          this.setStatus('error', errorMessage);
+        }
         fail(new Error(errorMessage));
       };
 
       // Without this, a close before onopen would leave the connect() Promise
       // pending forever, and the background reconnect loop would hang on it.
       socket.onclose = () => {
-        if (!isCurrentSocket()) return;
-        this.disconnect();
         logger.warn('WebSocket closed');
-        if (!opened) fail(new Error(`WebSocket closed before connection opened: ${wsUrl}`));
+        if (!opened) {
+          fail(new Error(`WebSocket closed before connection opened: ${wsUrl}`));
+          return;
+        }
+        if (isCurrentSocket()) this.disconnect();
       };
     });
   }

--- a/packages/backend/src/modules/electrumRpcClient.ts
+++ b/packages/backend/src/modules/electrumRpcClient.ts
@@ -60,8 +60,19 @@ export class ElectrumRpcClient {
       const wsUrl = `${protocol}${this.server.host}:${this.server.port}`;
       this.disconnect();
 
+      let opened = false;
+      let settled = false;
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        this.disconnect();
+        reject(error);
+      };
+
       this.socket = new WebSocket(wsUrl);
       this.socket.onopen = () => {
+        opened = true;
+        settled = true;
         logger.log(`Connected to Electrum server at ${wsUrl}`);
         this.setStatus('connected');
         resolve(this);
@@ -73,16 +84,18 @@ export class ElectrumRpcClient {
       };
 
       this.socket.onerror = (error: Event) => {
-        const errorMessage = 'WebSocket error: ' + (error as ErrorEvent).message || 'Unknown error';
+        const errorMessage = 'WebSocket error: ' + ((error as ErrorEvent).message || 'Unknown error');
         logger.error(errorMessage, error);
         this.setStatus('error', errorMessage);
-        this.disconnect();
-        reject(new Error(errorMessage));
+        fail(new Error(errorMessage));
       };
 
+      // Without this, a close before onopen would leave the connect() Promise
+      // pending forever, and the background reconnect loop would hang on it.
       this.socket.onclose = () => {
         this.disconnect();
         logger.warn('WebSocket closed');
+        if (!opened) fail(new Error(`WebSocket closed before connection opened: ${wsUrl}`));
       };
     });
   }

--- a/packages/backend/src/modules/electrumService.ts
+++ b/packages/backend/src/modules/electrumService.ts
@@ -34,8 +34,13 @@ export class ElectrumService {
     this.network = network;
     const { server, healthyServers } = await selectBestServer(this.network);
     this.healthyServers = healthyServers;
-    this.rpcClient = new ElectrumRpcClient(server);
-    this.rpcClient.onStatus.on(status => {
+    const client = new ElectrumRpcClient(server);
+    this.rpcClient = client;
+    // Old clients can still emit after a network switch — gate on identity so
+    // a stale 'disconnected' doesn't trigger background reconnect against the
+    // new client.
+    client.onStatus.on(status => {
+      if (this.rpcClient !== client) return;
       this.setStatus(status.status, status.detail);
     });
     return this;

--- a/packages/backend/src/modules/electrumService.ts
+++ b/packages/backend/src/modules/electrumService.ts
@@ -27,6 +27,7 @@ export class ElectrumService {
   private rpcClient: ElectrumRpcClient | undefined;
   private healthyServers: ExtendedServerConfig[] = [];
   private headerCache = new Map<number, string>();
+  private suppressClientDisconnectStatus = false;
   public status: ConnectionStatus = 'disconnected';
   public readonly onStatus = createEmitter<ConnectionUpdate>();
 
@@ -41,6 +42,13 @@ export class ElectrumService {
     // new client.
     client.onStatus.on(status => {
       if (this.rpcClient !== client) return;
+      // Suppress the secondary 'disconnected' that rpcClient.disconnect()
+      // emits during our own intentional teardown — the outer disconnect()
+      // already emitted the canonical event with the correct reason. Without
+      // this gate, the reasonless follow-up would slip past the background
+      // listener's `reason === 'switchNetwork'` check and schedule a
+      // reconnect against the old client while a network switch is in flight.
+      if (this.suppressClientDisconnectStatus && status.status === 'disconnected') return;
       this.setStatus(status.status, status.detail);
     });
     return this;
@@ -56,7 +64,12 @@ export class ElectrumService {
   public disconnect(reason?: string) {
     logger.log('Disconnecting Electrum server', reason);
     this.setStatus('disconnected', undefined, reason);
-    this.rpcClient?.disconnect();
+    this.suppressClientDisconnectStatus = true;
+    try {
+      this.rpcClient?.disconnect();
+    } finally {
+      this.suppressClientDisconnectStatus = false;
+    }
     this.headerCache.clear();
   }
 

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -74,6 +74,12 @@ export class WalletManager {
       historyService.reset();
       return true;
     } catch (err) {
+      // A failed electrumService.connect() emits a reasonless 'disconnected'
+      // which the background listener treats as a real drop and starts
+      // reconnecting against the failed target. Re-tag the teardown with
+      // 'switchNetwork' so the background cancels that in-flight retry
+      // before we rebuild state for the previous network.
+      electrumService.disconnect('switchNetwork');
       // Without a full rollback, the 'switchNetwork' disconnect reason suppresses
       // auto-reconnect and the wallet sits permanently on "Disconnected". We also
       // restore the previous account index — ensureDefaultAccount() may have moved
@@ -132,6 +138,9 @@ export class WalletManager {
         historyService.reset();
         return preferenceManager.get();
       } catch (err) {
+        // Re-tag the teardown so the background cancels any auto-reconnect
+        // that the failed connect()'s reasonless 'disconnected' triggered.
+        electrumService.disconnect('switchNetwork');
         logger.error('switchAccount network change failed, rolling back', err);
         await preferenceManager.update({ activeNetwork: previousNetwork, activeAccountIndex: previousAccountIndex });
         await wallet.restore(previousNetwork, sessionPassword).catch(() => undefined);

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -57,9 +57,10 @@ export class WalletManager {
     const sessionPassword = await getSessionPassword();
     if (!sessionPassword) return false;
 
-    const previousNetwork = preferenceManager.get().activeNetwork;
+    const previousPrefs = preferenceManager.get();
+    const previousNetwork = previousPrefs.activeNetwork;
+    const previousAccountIndex = previousPrefs.activeAccountIndex;
     electrumService.disconnect('switchNetwork');
-    scanManager.clear();
 
     try {
       await preferenceManager.update({ activeNetwork: network });
@@ -68,17 +69,27 @@ export class WalletManager {
       await electrumService.init(network);
       await electrumService.connect();
       await accountManager.init(preferenceManager.get().activeAccountIndex);
+      scanManager.clear();
       await scanManager.init();
       historyService.reset();
       return true;
     } catch (err) {
-      // Without this rollback, the 'switchNetwork' disconnect reason suppresses
-      // auto-reconnect and the wallet sits permanently on "Disconnected".
+      // Without a full rollback, the 'switchNetwork' disconnect reason suppresses
+      // auto-reconnect and the wallet sits permanently on "Disconnected". We also
+      // restore the previous account index — ensureDefaultAccount() may have moved
+      // it before init/connect failed, which would otherwise leave the previous
+      // network paired with the new network's account index.
       logger.error('switchNetwork failed, rolling back to previous network', err);
-      await preferenceManager.update({ activeNetwork: previousNetwork });
+      await preferenceManager.update({
+        activeNetwork: previousNetwork,
+        activeAccountIndex: previousAccountIndex,
+      });
       await wallet.restore(previousNetwork, sessionPassword).catch(() => undefined);
+      await accountManager.init(previousAccountIndex).catch(() => undefined);
+      scanManager.clear();
+      await scanManager.init().catch(() => undefined);
       await electrumService.init(previousNetwork).catch(() => undefined);
-      electrumService.connect().catch(() => undefined);
+      void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
       throw err;
     }
   }
@@ -119,8 +130,11 @@ export class WalletManager {
         logger.error('switchAccount network change failed, rolling back', err);
         await preferenceManager.update({ activeNetwork: previousNetwork, activeAccountIndex: previousAccountIndex });
         await wallet.restore(previousNetwork, sessionPassword).catch(() => undefined);
+        await accountManager.init(previousAccountIndex).catch(() => undefined);
+        scanManager.clear();
+        await scanManager.init().catch(() => undefined);
         await electrumService.init(previousNetwork).catch(() => undefined);
-        electrumService.connect().catch(() => undefined);
+        void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
         throw err;
       }
     } else {

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -120,12 +120,17 @@ export class WalletManager {
     if (networkChanged) {
       const previousNetwork = prefs.activeNetwork;
       const previousAccountIndex = prefs.activeAccountIndex;
-      electrumService.disconnect('switchNetwork');
       try {
+        electrumService.disconnect('switchNetwork');
         await preferenceManager.update({ activeNetwork: account.network, activeAccountIndex: accountListIndex });
         await wallet.restore(account.network, sessionPassword);
         await electrumService.init(account.network);
         await electrumService.connect();
+        await accountManager.init(accountListIndex);
+        scanManager.clear();
+        await scanManager.init();
+        historyService.reset();
+        return preferenceManager.get();
       } catch (err) {
         logger.error('switchAccount network change failed, rolling back', err);
         await preferenceManager.update({ activeNetwork: previousNetwork, activeAccountIndex: previousAccountIndex });
@@ -137,10 +142,9 @@ export class WalletManager {
         void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
         throw err;
       }
-    } else {
-      await preferenceManager.update({ activeAccountIndex: accountListIndex });
     }
 
+    await preferenceManager.update({ activeAccountIndex: accountListIndex });
     await accountManager.init(accountListIndex);
     scanManager.clear();
     await scanManager.init();

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -55,21 +55,32 @@ export class WalletManager {
 
   async switchNetwork(network: Network) {
     const sessionPassword = await getSessionPassword();
-    if (sessionPassword) {
-      electrumService.disconnect('switchNetwork');
-      scanManager.clear();
+    if (!sessionPassword) return false;
+
+    const previousNetwork = preferenceManager.get().activeNetwork;
+    electrumService.disconnect('switchNetwork');
+    scanManager.clear();
+
+    try {
       await preferenceManager.update({ activeNetwork: network });
-      await wallet.restore(preferenceManager.get().activeNetwork, sessionPassword);
+      await wallet.restore(network, sessionPassword);
       await this.ensureDefaultAccount();
-      await electrumService.init(preferenceManager.get().activeNetwork);
+      await electrumService.init(network);
       await electrumService.connect();
       await accountManager.init(preferenceManager.get().activeAccountIndex);
       await scanManager.init();
       historyService.reset();
       return true;
+    } catch (err) {
+      // Without this rollback, the 'switchNetwork' disconnect reason suppresses
+      // auto-reconnect and the wallet sits permanently on "Disconnected".
+      logger.error('switchNetwork failed, rolling back to previous network', err);
+      await preferenceManager.update({ activeNetwork: previousNetwork });
+      await wallet.restore(previousNetwork, sessionPassword).catch(() => undefined);
+      await electrumService.init(previousNetwork).catch(() => undefined);
+      electrumService.connect().catch(() => undefined);
+      throw err;
     }
-
-    return false;
   }
 
   /**
@@ -96,11 +107,22 @@ export class WalletManager {
     const networkChanged = prefs.activeNetwork !== account.network;
 
     if (networkChanged) {
+      const previousNetwork = prefs.activeNetwork;
+      const previousAccountIndex = prefs.activeAccountIndex;
       electrumService.disconnect('switchNetwork');
-      await preferenceManager.update({ activeNetwork: account.network, activeAccountIndex: accountListIndex });
-      await wallet.restore(account.network, sessionPassword);
-      await electrumService.init(account.network);
-      await electrumService.connect();
+      try {
+        await preferenceManager.update({ activeNetwork: account.network, activeAccountIndex: accountListIndex });
+        await wallet.restore(account.network, sessionPassword);
+        await electrumService.init(account.network);
+        await electrumService.connect();
+      } catch (err) {
+        logger.error('switchAccount network change failed, rolling back', err);
+        await preferenceManager.update({ activeNetwork: previousNetwork, activeAccountIndex: previousAccountIndex });
+        await wallet.restore(previousNetwork, sessionPassword).catch(() => undefined);
+        await electrumService.init(previousNetwork).catch(() => undefined);
+        electrumService.connect().catch(() => undefined);
+        throw err;
+      }
     } else {
       await preferenceManager.update({ activeAccountIndex: accountListIndex });
     }

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -94,8 +94,19 @@ export class WalletManager {
       await accountManager.init(previousAccountIndex).catch(() => undefined);
       scanManager.clear();
       await scanManager.init().catch(() => undefined);
-      await electrumService.init(previousNetwork).catch(() => undefined);
-      void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
+      // Only reconnect after init for the previous network actually succeeded —
+      // otherwise this.rpcClient is still the failed target-network client and
+      // connect() would reach for the wrong server while prefs sit on previous.
+      let restoredElectrum = false;
+      try {
+        await electrumService.init(previousNetwork);
+        restoredElectrum = true;
+      } catch (restoreErr) {
+        logger.error('rollback electrum init failed', restoreErr);
+      }
+      if (restoredElectrum) {
+        void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
+      }
       throw err;
     }
   }
@@ -147,8 +158,18 @@ export class WalletManager {
         await accountManager.init(previousAccountIndex).catch(() => undefined);
         scanManager.clear();
         await scanManager.init().catch(() => undefined);
-        await electrumService.init(previousNetwork).catch(() => undefined);
-        void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
+        // Same guard as switchNetwork: only reconnect after rollback init
+        // succeeds, otherwise we'd reconnect the failed target-network client.
+        let restoredElectrum = false;
+        try {
+          await electrumService.init(previousNetwork);
+          restoredElectrum = true;
+        } catch (restoreErr) {
+          logger.error('rollback electrum init failed', restoreErr);
+        }
+        if (restoredElectrum) {
+          void electrumService.connect().catch(error => logger.error('rollback reconnect failed', error));
+        }
         throw err;
       }
     }

--- a/packages/backend/tests/modules/electrumRpcClient.test.ts
+++ b/packages/backend/tests/modules/electrumRpcClient.test.ts
@@ -154,4 +154,30 @@ describe('ElectrumRpcClient', () => {
     ).not.toThrow();
     warnSpy.mockRestore();
   });
+
+  it('disconnect before onopen rejects the pending connect promise', async () => {
+    const c = new ElectrumRpcClient(cfg);
+    const p = c.connect();
+    const sock = FakeWebSocket.lastInstance!;
+    c.disconnect();
+    sock.triggerClose();
+    await expect(p).rejects.toThrow(/closed before connection opened/);
+  });
+
+  it('stale socket open does not resolve the current connection', async () => {
+    const c = new ElectrumRpcClient(cfg);
+
+    const stale = c.connect();
+    const staleSocket = FakeWebSocket.lastInstance!;
+
+    const current = c.connect();
+    const currentSocket = FakeWebSocket.lastInstance!;
+    expect(currentSocket).not.toBe(staleSocket);
+
+    staleSocket.triggerOpen();
+    await expect(stale).rejects.toThrow(/replaced before opening/);
+
+    currentSocket.triggerOpen();
+    await expect(current).resolves.toBe(c);
+  });
 });

--- a/packages/backend/tests/modules/electrumService.test.ts
+++ b/packages/backend/tests/modules/electrumService.test.ts
@@ -247,4 +247,12 @@ describe('ElectrumService', () => {
     expect(events[0].status).toBe('disconnected');
     expect(events[0].reason).toBe('manual stop');
   });
+
+  it('disconnect(switchNetwork) does not emit a second reasonless disconnected event', async () => {
+    const { svc } = await bootElectrumService();
+    const events: { status: string; reason?: string }[] = [];
+    svc.onStatus.on(e => events.push({ status: e.status, reason: e.reason }));
+    svc.disconnect('switchNetwork');
+    expect(events).toEqual([{ status: 'disconnected', reason: 'switchNetwork' }]);
+  });
 });


### PR DESCRIPTION
Switching network sometimes left the wallet stuck on "Disconnected" with no recovery. Two things were wrong:

1. `walletManager.switchNetwork` had no failure path. If `electrumService.init` or `connect` rejected on the new network, the wallet was left half-switched and the `switchNetwork` reason on the prior disconnect suppressed auto-reconnect — permanently disconnected.
2. The background auto-reconnect only tried once. After one failed attempt it gave up.

Changes:
- `switchNetwork` and `switchAccount` (when it crosses networks) now roll back to the previous network on failure.
- Background reconnect retries with exponential backoff (1s, 2s, 4s, … capped at 30s) and resets on success.

## Test plan
- [ ] Switch between mainnet and testnet a few times — status should always settle to Connected
- [ ] Block one of the chosen Electrum hosts (e.g. via /etc/hosts) and observe the reconnect loop backing off and recovering once the host is reachable again
- [ ] Switch account across networks and confirm rollback on a forced init failure