### PR TITLE
chore: gitignore tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ eslint.config.js
 .DS_Store
 .idea
 **/.turbo
+**/*.tsbuildinfo
 
 # compiled
 chrome-extension/public/manifest.json


### PR DESCRIPTION
Build artifact from `tsc --incremental`; regenerated every build, no reason to track it.