### PR TITLE
Drop unused Chrome permissions: scripting, activeTab, notifications

### DIFF
--- a/chrome-extension/manifest.js
+++ b/chrome-extension/manifest.js
@@ -27,7 +27,7 @@ const manifest = withSidePanel({
   version: packageJson.version,
   description: '__MSG_extensionDescription__',
   host_permissions: ['<all_urls>'],
-  permissions: ['storage', 'scripting', 'activeTab', 'notifications', 'alarms'],
+  permissions: ['storage', 'alarms'],
   background: {
     service_worker: 'background.js',
     type: 'module',


### PR DESCRIPTION
Removed scripting, activeTab and notifications from chrome-extension/manifest.js. None of them have any call sites in the repo.

- scripting: the wallet provider is injected via static content_scripts in make-manifest-plugin.ts, not via chrome.scripting
- activeTab: only chrome.tabs.create({url}) is used, which doesn't need it
- notifications: never called

storage and alarms stay (both used heavily). host_permissions <all_urls> stays for the in-page provider injection.

Smaller install warning, fewer fields to justify on the Chrome Web Store listing.