### PR TITLE
Switch turbo UI from tui to stream

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "ui": "tui",
+  "ui": "stream",
   "globalEnv": ["__FIREFOX__"],
   "daemon": false,
   "tasks": {


### PR DESCRIPTION
The tui mode needs a pty and crashes with 'failed to openpty: Device not configured' in terminals that don't provide one. Stream prints the same logs without the pty requirement.