### PR TITLE
Run clean scripts via pnpm -r instead of turbo

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "type": "module",
   "scripts": {
-    "clean:bundle": "rimraf dist && turbo clean:bundle",
-    "clean:node_modules": "pnpx rimraf node_modules && pnpx turbo clean:node_modules",
-    "clean:turbo": "rimraf .turbo && turbo clean:turbo",
+    "clean:bundle": "rimraf dist && pnpm -r --if-present run clean:bundle",
+    "clean:node_modules": "pnpx rimraf node_modules && pnpm -r --if-present run clean:node_modules",
+    "clean:turbo": "rimraf .turbo && pnpm -r --if-present run clean:turbo",
     "clean": "pnpm clean:bundle && pnpm clean:turbo && pnpm clean:node_modules",
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "pnpm clean:bundle && turbo ready && turbo build",


### PR DESCRIPTION
Turbo allocates a pty per task, and turbo 2.9.x on macOS errors with `openpty: Device not configured` even on a fresh shell with no daemon running. The `clean:*` scripts are pure `rimraf` calls (no dependency graph, no cache benefit), so switching them to `pnpm -r --if-present run` sidesteps turbo entirely. Build / dev / type-check / lint / test still use turbo.