### PR TITLE
Revert #145 (clean scripts off turbo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   },
   "type": "module",
   "scripts": {
-    "clean:bundle": "rimraf dist && pnpm -r --if-present run clean:bundle",
-    "clean:node_modules": "pnpx rimraf node_modules && pnpm -r --if-present run clean:node_modules",
-    "clean:turbo": "rimraf .turbo && pnpm -r --if-present run clean:turbo",
+    "clean:bundle": "rimraf dist && turbo clean:bundle",
+    "clean:node_modules": "pnpx rimraf node_modules && pnpx turbo clean:node_modules",
+    "clean:turbo": "rimraf .turbo && turbo clean:turbo",
     "clean": "pnpm clean:bundle && pnpm clean:turbo && pnpm clean:node_modules",
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "pnpm clean:bundle && turbo ready && turbo build",


### PR DESCRIPTION
Restores turbo on `clean:*` scripts. The openpty crash was system-level pty exhaustion (orphaned terminal-helper processes holding ptys), not a turbo issue, so this workaround wasn't the right fix.