### PR TITLE
Fix zpub to account-level node instead of master node

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
       "base-x@4": "4.0.1",
       "sha.js": "^2.4.12",
       "jiti": "^2.4.2",
-      "typescript": "5.7.3"
+      "typescript": "5.7.3",
+      "ws@>=8.0.0 <8.21.0": ">=8.21.0"
     }
   },
   "packageManager": "pnpm@9.15.1",

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -23,6 +23,7 @@ import { scriptTypeFromAddress } from './utils/crypto';
 import { verifyMerkleProof } from './utils/merkle';
 import { deleteSessionPassword, getSessionPassword } from './utils/sessionStorageHelper';
 import { convertToSlip0132 } from './utils/xpubConverter';
+import bs58check from 'bs58check';
 
 bitcoin.initEccLib(secp256k1);
 
@@ -414,15 +415,24 @@ export class WalletManager {
     return await wallet.getMnemonic(password);
   }
 
-  /**
-   * Get the xpub of the current wallet
-   */
+  /** Account-level zpub/ypub for the active account. Null if locked or no active account. */
   public getXpub() {
-    const xpub = wallet.getXpub();
-    if (!xpub) return null;
+    // master xpub is null when the wallet is locked, so bail before exporting anything
+    if (!wallet.getXpub()) return null;
 
-    const activeAccount = accountManager.getActiveAccount();
-    return convertToSlip0132(xpub, activeAccount.scriptType, activeAccount.network);
+    let activeAccount;
+    try {
+      activeAccount = accountManager.getActiveAccount();
+    } catch {
+      return null; // no active account (e.g. after logout)
+    }
+
+    // has to be the account node (depth 3), anything higher won't match the receive addresses
+    if (bs58check.decode(activeAccount.xpub)[4] !== 3) {
+      throw new Error('Refusing to export non-account-level extended public key');
+    }
+
+    return convertToSlip0132(activeAccount.xpub, activeAccount.scriptType, activeAccount.network);
   }
 
   /**

--- a/packages/backend/tests/integration/walletManager.test.ts
+++ b/packages/backend/tests/integration/walletManager.test.ts
@@ -1,4 +1,7 @@
 import * as bitcoin from 'bitcoinjs-lib';
+import BIP32Factory from 'bip32';
+import * as secp256k1 from '@bitcoinerlab/secp256k1';
+import bs58check from 'bs58check';
 import { resetChromeStorage } from '../helpers/chromeMock';
 import { installFetchMock, jsonResponse, mockFetch, resetFetchMock, restoreFetch } from '../helpers/fetchMock';
 import { walletManager } from '../../src/walletManager';
@@ -17,6 +20,18 @@ import { setSessionPassword } from '../../src/utils/sessionStorageHelper';
 
 const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 const PASSWORD = 'pw';
+
+const bip32 = BIP32Factory(secp256k1);
+
+// Swap SLIP-0132 version bytes back to a standard xpub/tpub, like an external tool does on import.
+function toStandardXpub(slip0132: string, network: Network): string {
+  const standardVersion = network === Network.Mainnet ? 0x0488b21e : 0x043587cf;
+  const decoded = bs58check.decode(slip0132);
+  const out = new Uint8Array(decoded.length);
+  out.set(decoded);
+  new DataView(out.buffer).setUint32(0, standardVersion, false);
+  return bs58check.encode(out);
+}
 
 async function freshState(): Promise<void> {
   resetChromeStorage();
@@ -98,6 +113,36 @@ describe('WalletManager — full lifecycle (integration)', () => {
     await walletManager.createWallet(MNEMONIC, PASSWORD);
     wallet.clear();
     expect(walletManager.getXpub()).toBeNull();
+  });
+
+  it('getXpub() returns null (does not throw) when no account is active', async () => {
+    await walletManager.createWallet(MNEMONIC, PASSWORD);
+    accountManager.activeAccountIndex = -1;
+    expect(walletManager.getXpub()).toBeNull();
+  });
+
+  // Regression: the export used to encode the master node (depth 0), so addresses derived from
+  // the zpub didn't match the wallet's receive addresses. Re-derive the way an external tool would.
+  it('exported zpub re-derives the wallet’s own receive addresses (account-level, depth 3)', async () => {
+    await walletManager.createWallet(MNEMONIC, PASSWORD);
+
+    const zpub = walletManager.getXpub();
+    expect(zpub).toMatch(/^zpub/);
+    expect(bs58check.decode(zpub!)[4]).toBe(3); // account node, not the master's 0
+
+    const node = bip32.fromBase58(toStandardXpub(zpub!, Network.Mainnet), bitcoin.networks.bitcoin);
+    const addressFromZpub = (index: number) =>
+      bitcoin.payments.p2wpkh({
+        pubkey: Buffer.from(node.derive(0).derive(index).publicKey),
+        network: bitcoin.networks.bitcoin,
+      }).address;
+
+    for (let index = 0; index < 3; index++) {
+      expect(addressFromZpub(index)).toBe(walletManager.deriveAddress(0, index));
+    }
+
+    // Pin the canonical address, not just self-consistency between the two paths.
+    expect(addressFromZpub(0)).toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
   });
 
   it('switchEvmNetwork() updates the activeEvmNetwork preference only', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   sha.js: ^2.4.12
   jiti: ^2.4.2
   typescript: 5.7.3
+  ws@>=8.0.0 <8.21.0: '>=8.21.0'
 
 importers:
 
@@ -236,8 +237,8 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.10.12)(@types/node@25.6.2)(typescript@5.7.3)
       ws:
-        specifier: 8.18.0
-        version: 8.18.0
+        specifier: '>=8.21.0'
+        version: 8.21.0
 
   packages/shared:
     devDependencies:
@@ -4009,20 +4010,8 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6131,7 +6120,7 @@ snapshots:
       '@types/node': 22.7.5
       aes-js: 4.0.0-beta.5
       tslib: 2.7.0
-      ws: 8.17.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -8331,9 +8320,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
-  ws@8.17.1: {}
-
-  ws@8.18.0: {}
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
This PR [fixes issue where zpub generated was derived from master node instead of account node,](https://app.notion.com/p/blockonomics/Chui-Prod-zpub-generated-is-wrong-380fef554adf80cc8f4bdd8245e48cfc) resulting in the addresses chui wallet generated differ from other wallets