### PR TITLE
Implement compute send max to sweep utxo and fee sizing

### DIFF
--- a/chrome-extension/src/background/messaging/action.ts
+++ b/chrome-extension/src/background/messaging/action.ts
@@ -464,6 +464,21 @@ const handlers: Record<string, Handler> = {
     return adapter.estimateFee(to, amount, options);
   },
 
+  'chain.estimateMaxSend': async params => {
+    const payload = expectObjectParams('chain.estimateMaxSend', params);
+    const chain = expectEnumParam('chain.estimateMaxSend', payload, 'chain', Object.values(ChainType));
+    const to = expectStringParam('chain.estimateMaxSend', payload, 'to');
+    const rawOptions = payload.options;
+    const options =
+      rawOptions === undefined
+        ? undefined
+        : (expectObjectParams('chain.estimateMaxSend.options', rawOptions) as ChainSendOptions);
+    const adapter = chainRegistry.get(chain);
+    if (!adapter) throw new Error(`Unsupported chain: ${chain}`);
+    if (!adapter.estimateMaxSend) throw new Error(`chain.estimateMaxSend not supported for ${chain}`);
+    return adapter.estimateMaxSend(to, options);
+  },
+
   'chain.sendPayment': async params => {
     await requireUnlockedWallet('chain.sendPayment');
     const payload = expectObjectParams('chain.sendPayment', params);

--- a/packages/backend/src/adapters/BitcoinAdapter.ts
+++ b/packages/backend/src/adapters/BitcoinAdapter.ts
@@ -13,6 +13,7 @@ import {
   type ChainTransaction,
   type ChainTransactionHistoryOptions,
   type ChainFeeEstimate,
+  type ChainMaxSendEstimate,
   type ChainSendOptions,
 } from './IChainAdapter';
 
@@ -109,7 +110,17 @@ export class BitcoinAdapter implements IChainAdapter {
 
   async sendPayment(to: string, amount: string, options?: ChainSendOptions): Promise<string> {
     const feeRate = options?.feeRate ?? 1;
-    return this.walletManager.sendPayment(to, this.parseBtcAmountToSats(amount), feeRate);
+    const isMax = options?.isMax === true;
+    return this.walletManager.sendPayment(to, this.parseBtcAmountToSats(amount), feeRate, isMax);
+  }
+
+  async estimateMaxSend(to: string, options?: ChainSendOptions): Promise<ChainMaxSendEstimate> {
+    const feeRate = options?.feeRate ?? 1;
+    const { amountSats, feeSats } = await this.walletManager.getMaxSendAmount(to, feeRate);
+    return {
+      amount: amountSats / 1e8,
+      fee: feeSats / 1e8,
+    };
   }
 
   async estimateFee(to: string, _amount?: string, _options?: ChainSendOptions): Promise<ChainFeeEstimate[]> {

--- a/packages/backend/src/adapters/IChainAdapter.ts
+++ b/packages/backend/src/adapters/IChainAdapter.ts
@@ -78,6 +78,18 @@ export interface ChainFeeEstimate {
 }
 
 /**
+ * Max-sendable amount for a sweep (entire balance to one recipient), with the
+ * real on-chain fee already netted off. Only meaningful for chains where the
+ * fee is paid out of the same balance being sent (e.g. BTC).
+ */
+export interface ChainMaxSendEstimate {
+  /** Max sendable amount in display units, after the fee */
+  amount: number;
+  /** Fee in display units */
+  fee: number;
+}
+
+/**
  * Options for sending a transaction
  */
 export interface ChainSendOptions {
@@ -95,6 +107,8 @@ export interface ChainSendOptions {
   tokenSymbol?: string;
   /** For ERC-20 transfers */
   tokenAddress?: string;
+  /** Sweep the entire spendable balance to `to`, netting the real fee off the amount sent */
+  isMax?: boolean;
 }
 
 /**
@@ -155,4 +169,7 @@ export interface IChainAdapter {
 
   /** Estimate fees for a transaction */
   estimateFee(to: string, amount?: string, options?: ChainSendOptions): Promise<ChainFeeEstimate[]>;
+
+  /** Compute the true max sendable amount for a sweep, netting the real fee off the balance */
+  estimateMaxSend?(to: string, options?: ChainSendOptions): Promise<ChainMaxSendEstimate>;
 }

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -3,6 +3,7 @@ import type { SpendableUtxo, utxoSelectionResult } from './modules/utxoSelection
 import type { AddressEntry, UtxoEntry } from './types/cache';
 import type { Network } from './types/electrum';
 import type { Balance } from './types/wallet';
+import type { FeeSizer } from './modules/feeService';
 import { CacheType, ChangeType } from './types/cache';
 import browser from 'webextension-polyfill';
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
@@ -272,6 +273,38 @@ export class WalletManager {
     }
   }
 
+  /**
+   * UTXOs eligible for a sweep. Mirrors getBalance's spendable definition: confirmed external
+   * UTXOs plus our own pending change (trusted immediately); never unconfirmed external deposits.
+   */
+  private sweepableUtxos(utxos: SpendableUtxo[]): SpendableUtxo[] {
+    return utxos.filter(u => u.height > 0 || u.chain === ChangeType.Internal);
+  }
+
+  /** Inputs, fee, and amount for sweeping every spendable UTXO to `to` in one output, no change. */
+  private sweepAmount(
+    utxos: SpendableUtxo[],
+    feeSizer: FeeSizer,
+  ): { inputs: SpendableUtxo[]; amountSats: number; feeSats: number } {
+    const inputs = this.sweepableUtxos(utxos);
+    const total = inputs.reduce((sum, u) => sum + u.value, 0);
+    const feeSats = feeSizer(inputs.length, false);
+    return { inputs, amountSats: total - feeSats, feeSats };
+  }
+
+  public async getMaxSendAmount(
+    toAddress: string,
+    feerateSatPerVb: number,
+  ): Promise<{ amountSats: number; feeSats: number }> {
+    const utxos = await this.getUtxos();
+    const account = accountManager.getActiveAccount();
+    const toScript = scriptTypeFromAddress(toAddress);
+    const feeSizer = feeService.createFeeSizer(feerateSatPerVb, account.scriptType, toScript);
+    const { inputs, amountSats, feeSats } = this.sweepAmount(utxos, feeSizer);
+    if (inputs.length === 0 || amountSats <= 0) throw new Error('Insufficient funds');
+    return { amountSats, feeSats };
+  }
+
   public async getUtxos(): Promise<SpendableUtxo[]> {
     // Storage keys written by ScanManager
     const rxUtxoKey = getCacheKey(CacheType.Utxo, ChangeType.External);
@@ -340,15 +373,27 @@ export class WalletManager {
   /**
    * Builds, signs, and broadcasts a PAYMENT (spend to one recipient).
    */
-  public async sendPayment(to: string, amountSats: number, feerateSatPerVb: number): Promise<string> {
+  public async sendPayment(to: string, amountSats: number, feerateSatPerVb: number, isMax = false): Promise<string> {
     logger.log(`Sending ${amountSats} to ${to} at the rate of ${feerateSatPerVb}`);
     const utxos = await this.getUtxos();
     const account = accountManager.getActiveAccount();
     const changeScript = account.scriptType;
     const toScript = scriptTypeFromAddress(to);
     const feeSizer = feeService.createFeeSizer(feerateSatPerVb, changeScript, toScript);
-    const selectedUtxo: utxoSelectionResult = selectUtxo(utxos, amountSats, feeSizer, feeService.DUST[changeScript]);
-    const outputs: Array<{ address: string; value: number }> = [{ address: to, value: amountSats }];
+
+    let selectedUtxo: utxoSelectionResult;
+    let sendAmountSats: number;
+    if (isMax) {
+      const swept = this.sweepAmount(utxos, feeSizer);
+      if (swept.inputs.length === 0 || swept.amountSats <= 0) throw new Error('Insufficient funds');
+      sendAmountSats = swept.amountSats;
+      selectedUtxo = { inputs: swept.inputs, change: 0, fee: swept.feeSats };
+    } else {
+      sendAmountSats = amountSats;
+      selectedUtxo = selectUtxo(utxos, amountSats, feeSizer, feeService.DUST[changeScript]);
+    }
+
+    const outputs: Array<{ address: string; value: number }> = [{ address: to, value: sendAmountSats }];
     if (selectedUtxo.change > 0) {
       const changeAddr = this.getAddress(ChangeType.Internal);
       if (!changeAddr) throw new Error('Unable to derive change address');
@@ -375,7 +420,7 @@ export class WalletManager {
         txid: localTxid,
         toAddress: to,
         fromAddress: selectedUtxo.inputs[0].address,
-        amountSats,
+        amountSats: sendAmountSats,
         feeSats: selectedUtxo.fee,
       });
     } catch (err) {

--- a/packages/backend/src/walletManager.ts
+++ b/packages/backend/src/walletManager.ts
@@ -301,7 +301,7 @@ export class WalletManager {
     const toScript = scriptTypeFromAddress(toAddress);
     const feeSizer = feeService.createFeeSizer(feerateSatPerVb, account.scriptType, toScript);
     const { inputs, amountSats, feeSats } = this.sweepAmount(utxos, feeSizer);
-    if (inputs.length === 0 || amountSats <= 0) throw new Error('Insufficient funds');
+    if (inputs.length === 0 || amountSats < feeService.DUST[toScript]) throw new Error('Insufficient funds');
     return { amountSats, feeSats };
   }
 
@@ -385,8 +385,12 @@ export class WalletManager {
     let sendAmountSats: number;
     if (isMax) {
       const swept = this.sweepAmount(utxos, feeSizer);
-      if (swept.inputs.length === 0 || swept.amountSats <= 0) throw new Error('Insufficient funds');
-      sendAmountSats = swept.amountSats;
+      if (swept.inputs.length === 0 || swept.amountSats < feeService.DUST[toScript]) {
+        throw new Error('Insufficient funds');
+      }
+      // Broadcast exactly what the preview approved; if the sweep shifted since, abort.
+      if (swept.amountSats !== amountSats) throw new Error('Max send amount changed');
+      sendAmountSats = amountSats;
       selectedUtxo = { inputs: swept.inputs, change: 0, fee: swept.feeSats };
     } else {
       sendAmountSats = amountSats;

--- a/packages/backend/tests/adapters/BitcoinAdapter.test.ts
+++ b/packages/backend/tests/adapters/BitcoinAdapter.test.ts
@@ -35,6 +35,7 @@ function makeStubs() {
       { speed: 'fast', sats: 10, btcAmount: 0.0006, usdAmount: 36 },
     ]),
     sendPayment: jest.fn(async () => 'txhashAAA'),
+    getMaxSendAmount: jest.fn(async () => ({ amountSats: 199_998_750, feeSats: 1_250 })),
   };
   const electrum = { init: jest.fn(), connect: jest.fn(), disconnect: jest.fn() };
   const scan = {};
@@ -180,14 +181,29 @@ describe('BitcoinAdapter — sendPayment + estimateFee', () => {
     const { wallet, electrum, scan, history } = makeStubs();
     const a = new BitcoinAdapter(wallet, electrum, scan, history);
     await a.sendPayment('bc1qrecv', '0.5');
-    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 50_000_000, 1);
+    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 50_000_000, 1, false);
   });
 
   it('parses BTC string with feeRate option', async () => {
     const { wallet, electrum, scan, history } = makeStubs();
     const a = new BitcoinAdapter(wallet, electrum, scan, history);
     await a.sendPayment('bc1qrecv', '1', { feeRate: 7 });
-    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 100_000_000, 7);
+    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 100_000_000, 7, false);
+  });
+
+  it('forwards isMax to sweep the whole balance', async () => {
+    const { wallet, electrum, scan, history } = makeStubs();
+    const a = new BitcoinAdapter(wallet, electrum, scan, history);
+    await a.sendPayment('bc1qrecv', '1', { feeRate: 7, isMax: true });
+    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 100_000_000, 7, true);
+  });
+
+  it('estimateMaxSend converts the sweep amount and fee to BTC', async () => {
+    const { wallet, electrum, scan, history } = makeStubs();
+    const a = new BitcoinAdapter(wallet, electrum, scan, history);
+    const estimate = await a.estimateMaxSend('bc1qrecv', { feeRate: 7 });
+    expect(wallet.getMaxSendAmount).toHaveBeenCalledWith('bc1qrecv', 7);
+    expect(estimate).toEqual({ amount: 1.9999875, fee: 0.0000125 });
   });
 
   it('rejects amounts with too many decimals', async () => {
@@ -212,7 +228,7 @@ describe('BitcoinAdapter — sendPayment + estimateFee', () => {
     const { wallet, electrum, scan, history } = makeStubs();
     const a = new BitcoinAdapter(wallet, electrum, scan, history);
     await a.sendPayment('bc1qrecv', '.5');
-    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 50_000_000, 1);
+    expect(wallet.sendPayment).toHaveBeenCalledWith('bc1qrecv', 50_000_000, 1, false);
   });
 
   it('estimateFee maps three speeds to ChainFeeEstimate[]', async () => {

--- a/packages/backend/tests/integration/walletManager.test.ts
+++ b/packages/backend/tests/integration/walletManager.test.ts
@@ -435,5 +435,26 @@ describe('WalletManager — full lifecycle (integration)', () => {
       // Only the confirmed 500_000 UTXO is swept; the unconfirmed deposit is left out.
       expect(amountSats + feeSats).toBe(500_000);
     });
+
+    it('aborts an isMax send when the approved amount no longer matches the current sweep', async () => {
+      await setupMultiUtxoWallet([400_000, 300_000, 300_000]);
+      jest
+        .spyOn(electrumService, 'broadcastTx')
+        .mockImplementation(async (hex: string) => bitcoin.Transaction.fromHex(hex).getId());
+
+      const { amountSats } = await walletManager.getMaxSendAmount(TO_ADDR, 5);
+      // One sat off the real sweep stands in for UTXOs shifting between preview and confirm.
+      await expect(walletManager.sendPayment(TO_ADDR, amountSats - 1, 5, true)).rejects.toThrow(
+        'Max send amount changed',
+      );
+
+      jest.restoreAllMocks();
+    });
+
+    it('getMaxSendAmount rejects a balance that nets a positive but sub-dust output', async () => {
+      // 700 sats total, fee 560 at 5 sat/vB leaves 140 — above zero but below the 330 dust floor.
+      await setupMultiUtxoWallet([700]);
+      await expect(walletManager.getMaxSendAmount(TO_ADDR, 5)).rejects.toThrow('Insufficient funds');
+    });
   });
 });

--- a/packages/backend/tests/integration/walletManager.test.ts
+++ b/packages/backend/tests/integration/walletManager.test.ts
@@ -333,4 +333,107 @@ describe('WalletManager — full lifecycle (integration)', () => {
       jest.restoreAllMocks();
     });
   });
+
+  describe('send-max sweep', () => {
+    const TO_ADDR = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+
+    async function setupMultiUtxoWallet(values: number[]) {
+      await walletManager.createWallet(MNEMONIC, PASSWORD);
+      const ownAddr = walletManager.deriveAddress(0, 0)!;
+      const utxoKey = getCacheKey(CacheType.Utxo, ChangeType.External);
+      const addrKey = getCacheKey(CacheType.Address, ChangeType.External);
+      await chrome.storage.local.set({
+        [addrKey]: [[0, { address: ownAddr, firstSeen: 0, lastChecked: 0, everUsed: true }]],
+        [utxoKey]: [
+          [
+            0,
+            {
+              lastChecked: 0,
+              utxos: values.map((value, i) => ({ txid: `${i}`.repeat(64), vout: 0, value, height: 800_000 })),
+            },
+          ],
+        ],
+      });
+    }
+
+    it('getMaxSendAmount nets the real multi-input fee off the total balance', async () => {
+      await setupMultiUtxoWallet([400_000, 300_000, 300_000]);
+
+      const { amountSats, feeSats } = await walletManager.getMaxSendAmount(TO_ADDR, 5);
+
+      // No leftover: the whole balance is accounted for between the recipient and the fee.
+      expect(amountSats + feeSats).toBe(1_000_000);
+      expect(amountSats).toBeGreaterThan(0);
+    });
+
+    it('sendPayment(isMax) sweeps every UTXO into a single change-less output', async () => {
+      await setupMultiUtxoWallet([400_000, 300_000, 300_000]);
+      jest.spyOn(scanManager, 'forwardScan').mockResolvedValue();
+      jest.spyOn(historyService, 'addOptimisticPending').mockResolvedValue();
+      let broadcastHex = '';
+      jest.spyOn(electrumService, 'broadcastTx').mockImplementation(async (hex: string) => {
+        broadcastHex = hex;
+        return bitcoin.Transaction.fromHex(hex).getId();
+      });
+
+      const { amountSats } = await walletManager.getMaxSendAmount(TO_ADDR, 5);
+      await walletManager.sendPayment(TO_ADDR, amountSats, 5, true);
+
+      const tx = bitcoin.Transaction.fromHex(broadcastHex);
+      expect(tx.ins).toHaveLength(3);
+      expect(tx.outs).toHaveLength(1);
+      expect(tx.outs[0].value).toBe(amountSats);
+
+      jest.restoreAllMocks();
+    });
+
+    it('a max amount sized for a single input throws Insufficient funds across 3 real UTXOs, unlike the sweep path', async () => {
+      await setupMultiUtxoWallet([400_000, 300_000, 300_000]);
+      jest.spyOn(scanManager, 'forwardScan').mockResolvedValue();
+      jest.spyOn(historyService, 'addOptimisticPending').mockResolvedValue();
+      jest
+        .spyOn(electrumService, 'broadcastTx')
+        .mockImplementation(async (hex: string) => bitcoin.Transaction.fromHex(hex).getId());
+
+      // What the old UI math produced: balance minus a fee sized for 1 input + 1 change output,
+      // regardless of how many UTXOs actually exist. With 3 UTXOs the real fee is bigger than
+      // this guess, so this amount isn't actually affordable.
+      const staleFeeGuess = Math.ceil((10 + 2 + 68 + 1 + 31 + 31) * 5);
+      const staleMaxAmount = 1_000_000 - staleFeeGuess;
+
+      await expect(walletManager.sendPayment(TO_ADDR, staleMaxAmount, 5)).rejects.toThrow('Insufficient funds');
+
+      const { amountSats } = await walletManager.getMaxSendAmount(TO_ADDR, 5);
+      expect(amountSats).toBeLessThan(staleMaxAmount);
+      await expect(walletManager.sendPayment(TO_ADDR, amountSats, 5, true)).resolves.toEqual(expect.any(String));
+
+      jest.restoreAllMocks();
+    });
+
+    it('excludes unconfirmed external UTXOs from the sweep', async () => {
+      await walletManager.createWallet(MNEMONIC, PASSWORD);
+      const ownAddr = walletManager.deriveAddress(0, 0)!;
+      const utxoKey = getCacheKey(CacheType.Utxo, ChangeType.External);
+      const addrKey = getCacheKey(CacheType.Address, ChangeType.External);
+      await chrome.storage.local.set({
+        [addrKey]: [[0, { address: ownAddr, firstSeen: 0, lastChecked: 0, everUsed: true }]],
+        [utxoKey]: [
+          [
+            0,
+            {
+              lastChecked: 0,
+              utxos: [
+                { txid: 'a'.repeat(64), vout: 0, value: 500_000, height: 800_000 },
+                { txid: 'b'.repeat(64), vout: 0, value: 500_000, height: 0 }, // unconfirmed external
+              ],
+            },
+          ],
+        ],
+      });
+
+      const { amountSats, feeSats } = await walletManager.getMaxSendAmount(TO_ADDR, 5);
+      // Only the confirmed 500_000 UTXO is swept; the unconfirmed deposit is left out.
+      expect(amountSats + feeSats).toBe(500_000);
+    });
+  });
 });

--- a/packages/backend/tests/modules/txHistoryService.test.ts
+++ b/packages/backend/tests/modules/txHistoryService.test.ts
@@ -1,7 +1,7 @@
 import { resetChromeStorage } from '../helpers/chromeMock';
 import { installFetchMock, jsonResponse, mockFetch, resetFetchMock, restoreFetch } from '../helpers/fetchMock';
 import { TxHistoryService } from '../../src/modules/txHistoryService';
-import { ChangeType, type AddressEntry, type HistoryEntry } from '../../src/types/cache';
+import { type AddressEntry, type HistoryEntry } from '../../src/types/cache';
 import { Network } from '../../src/types/electrum';
 import { ScriptType } from '../../src/types/wallet';
 import { accountManager } from '../../src/accountManager';

--- a/pages/popup/src/components/FeeOption.tsx
+++ b/pages/popup/src/components/FeeOption.tsx
@@ -11,6 +11,7 @@ export interface FeeOptionProps {
   symbol: string;
   fiatCurrency?: string;
   selected: boolean;
+  disabled?: boolean;
   onSelect?: () => void;
 }
 
@@ -23,6 +24,7 @@ export const FeeOption: React.FC<FeeOptionProps> = ({
   symbol,
   fiatCurrency = 'USD',
   selected,
+  disabled = false,
   onSelect,
 }) => {
   const iconVariant = (name ?? 'Medium').toLowerCase();
@@ -33,7 +35,9 @@ export const FeeOption: React.FC<FeeOptionProps> = ({
   return (
     <button
       onClick={onSelect}
-      className={`flex flex-col justify-center items-center px-auto rounded-2xl border border-solid h-[110px] min-h-[110px] w-[110px] gap-1 cursor-pointer 
+      disabled={disabled}
+      className={`flex flex-col justify-center items-center px-auto rounded-2xl border border-solid h-[110px] min-h-[110px] w-[110px] gap-1
+        ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}
         ${selected ? 'bg-background-14 border-primary-yellow' : 'bg-background-2c border-background-1d'}`}>
       <div className="w-full flex justify-center">
         <img

--- a/pages/popup/src/constants/index.ts
+++ b/pages/popup/src/constants/index.ts
@@ -12,6 +12,7 @@ export const ERROR_MESSAGES = {
   SEND_TRANSACTION_TOO_SMALL: 'Transaction amount is too small. Please increase the amount.',
   SEND_TRANSACTION_INSUFFICIENT_FUNDS: 'Insufficient funds to complete this transaction.',
   SEND_TRANSACTION_FEE_ERROR: 'Transaction fee error. Please try adjusting the fee.',
+  SEND_MAX_AMOUNT_CHANGED: 'Your balance changed. Tap Send Max again to update the amount.',
   PASSWORD_NOT_FOUND: 'No password found. Please restart the setup process.',
   UNEXPECTED_ERROR: 'An unexpected error occurred. Please try again.',
 };

--- a/pages/popup/src/pages/send/SendOptions.tsx
+++ b/pages/popup/src/pages/send/SendOptions.tsx
@@ -311,6 +311,7 @@ export const SendOptions: React.FC = () => {
     maxSendRequestRef.current++;
     setIsMaxSend(false);
     setMaxSendFee(null);
+    setMaxSendLoading(false);
   };
 
   // BTC's true max needs real UTXO selection on the backend, since the fee scales with the
@@ -526,7 +527,7 @@ export const SendOptions: React.FC = () => {
             value={usdAmount}
             onChange={handleUsdAmountChange}
             hasIcon={false}
-            disabled={feeEstimatesLoading || fiatRate === null}
+            disabled={feeEstimatesLoading || fiatRate === null || maxSendLoading}
           />
         </div>
         {fiatRate === null && (
@@ -569,6 +570,7 @@ export const SendOptions: React.FC = () => {
                   symbol={meta.symbol}
                   fiatCurrency={preferences?.fiatCurrency || 'USD'}
                   selected={selectedFeeIndex === index}
+                  disabled={maxSendLoading}
                   onSelect={() => setSelectedFeeIndex(index)}
                 />
               ))

--- a/pages/popup/src/pages/send/SendOptions.tsx
+++ b/pages/popup/src/pages/send/SendOptions.tsx
@@ -336,6 +336,10 @@ export const SendOptions: React.FC = () => {
     } catch (maxSendError) {
       if (requestId !== maxSendRequestRef.current) return;
       console.error('Failed to compute max send amount', maxSendError);
+      setIsMaxSend(false);
+      setMaxSendFee(null);
+      setAssetAmount('');
+      setUsdAmount('');
       setError('Insufficient funds');
     } finally {
       if (requestId === maxSendRequestRef.current) setMaxSendLoading(false);
@@ -365,6 +369,20 @@ export const SendOptions: React.FC = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFeeIndex]);
+
+  const handleFeeSelect = (index: number) => {
+    if (index === selectedFeeIndex) return;
+    // Drop the amount that was netted against the old fee so it can't be sent before the
+    // re-estimate lands. BTC re-estimates async, so hold the loading state until it returns.
+    if (isMaxSend && !usesSeparateFeeAsset) {
+      maxSendRequestRef.current++;
+      setMaxSendFee(null);
+      setAssetAmount('');
+      setUsdAmount('');
+      setMaxSendLoading(meta.chain === ChainType.Bitcoin);
+    }
+    setSelectedFeeIndex(index);
+  };
 
   const handleNext = () => {
     if (!currency || !states?.destinationAddress || !selectedFee) {
@@ -571,7 +589,7 @@ export const SendOptions: React.FC = () => {
                   fiatCurrency={preferences?.fiatCurrency || 'USD'}
                   selected={selectedFeeIndex === index}
                   disabled={maxSendLoading}
-                  onSelect={() => setSelectedFeeIndex(index)}
+                  onSelect={() => handleFeeSelect(index)}
                 />
               ))
             )}

--- a/pages/popup/src/pages/send/SendOptions.tsx
+++ b/pages/popup/src/pages/send/SendOptions.tsx
@@ -2,7 +2,7 @@ import type * as React from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { AmountInputField } from '@src/components/AmountInputField';
 import { FeeOption } from '@src/components/FeeOption';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getBtcFiatRate } from '@src/utils';
 import { Button } from '@src/components/Button';
 import Header from '@src/components/Header';
@@ -15,7 +15,12 @@ import {
   isSupportedSendCurrency,
 } from '@src/utils/currencyMeta';
 import { currencyMapping, type BalanceData, type Currencies } from '@src/types';
-import { ChainType, type ChainBalance, type ChainFeeEstimate } from '@extension/backend/src/adapters/IChainAdapter';
+import {
+  ChainType,
+  type ChainBalance,
+  type ChainFeeEstimate,
+  type ChainMaxSendEstimate,
+} from '@extension/backend/src/adapters/IChainAdapter';
 import Skeleton from 'react-loading-skeleton';
 
 interface SendOptionsState {
@@ -70,6 +75,13 @@ export const SendOptions: React.FC = () => {
   );
   const [lastEditedField, setLastEditedField] = useState<'asset' | 'usd'>('asset');
   const [error, setError] = useState('');
+  const [isMaxSend, setIsMaxSend] = useState(false);
+  const [maxSendLoading, setMaxSendLoading] = useState(false);
+  // Fee to display for the current max selection, when it differs from the plain estimate
+  // (BTC sweep fee scales with the real input count). Null when not a max send.
+  const [maxSendFee, setMaxSendFee] = useState<number | null>(null);
+  // Guards against a stale estimateMaxSend response overwriting a newer one.
+  const maxSendRequestRef = useRef(0);
 
   useEffect(() => {
     if (!currency) {
@@ -293,6 +305,66 @@ export const SendOptions: React.FC = () => {
 
   const selectedFee = feeOptions[selectedFeeIndex];
 
+  // Drop max-send state and invalidate any in-flight estimate so a late response can't
+  // overwrite a manually edited amount.
+  const clearMaxSend = () => {
+    maxSendRequestRef.current++;
+    setIsMaxSend(false);
+    setMaxSendFee(null);
+  };
+
+  // BTC's true max needs real UTXO selection on the backend, since the fee scales with the
+  // input count. Netting a flat fee estimate off the balance under- or over-shoots.
+  const runBtcMaxSend = async () => {
+    if (!selectedFee || !states?.destinationAddress) return;
+    const requestId = ++maxSendRequestRef.current;
+    setMaxSendLoading(true);
+    try {
+      const estimate = await sendMessage<ChainMaxSendEstimate>('chain.estimateMaxSend', {
+        chain: meta.chain,
+        to: states.destinationAddress,
+        options: selectedFee.sendOptions,
+      });
+      if (requestId !== maxSendRequestRef.current) return;
+      const maxAmount = Math.max(estimate.amount, 0);
+      setError(maxAmount <= 0 ? 'Insufficient balance' : '');
+      setIsMaxSend(true);
+      setMaxSendFee(estimate.fee);
+      setLastEditedField('asset');
+      setAssetAmount(formatInputAmount(maxAmount, assetDigits));
+    } catch (maxSendError) {
+      if (requestId !== maxSendRequestRef.current) return;
+      console.error('Failed to compute max send amount', maxSendError);
+      setError('Insufficient funds');
+    } finally {
+      if (requestId === maxSendRequestRef.current) setMaxSendLoading(false);
+    }
+  };
+
+  // Native account-based chains (ETH): the fee is paid from the same balance, so the max is
+  // simply balance minus the flat gas estimate.
+  const applyNativeMaxSend = () => {
+    if (availableBalance === null || !selectedFee) return;
+    const maxAmount = Math.max(availableBalance - selectedFee.fee, 0);
+    setError(maxAmount <= 0 ? 'Insufficient balance' : '');
+    setIsMaxSend(true);
+    setMaxSendFee(selectedFee.fee);
+    setLastEditedField('asset');
+    setAssetAmount(formatInputAmount(maxAmount, assetDigits));
+  };
+
+  // Re-derive the max amount if the user switches fee speed after hitting "Send Max" —
+  // a higher rate can eat into the amount a lower rate had left affordable.
+  useEffect(() => {
+    if (!isMaxSend || usesSeparateFeeAsset || !selectedFee || !states?.destinationAddress) return;
+    if (meta.chain === ChainType.Bitcoin) {
+      void runBtcMaxSend();
+    } else {
+      applyNativeMaxSend();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedFeeIndex]);
+
   const handleNext = () => {
     if (!currency || !states?.destinationAddress || !selectedFee) {
       return;
@@ -325,7 +397,9 @@ export const SendOptions: React.FC = () => {
         setError(`Insufficient ${meta.networkFeeSymbol} for network fee`);
         return;
       }
-    } else {
+    } else if (!isMaxSend) {
+      // Skip this check for a max send: the amount was already derived from the fee it's
+      // netted against, so re-checking against a re-subtracted fee only risks rounding drift.
       const maxSpendable = availableBalance - selectedFee.fee;
       if (maxSpendable < parsedAssetAmount) {
         setError('Insufficient funds');
@@ -333,22 +407,31 @@ export const SendOptions: React.FC = () => {
       }
     }
 
+    // For a max send, show the fee the amount was actually netted against, not the flat estimate.
+    const feeAmount = isMaxSend && maxSendFee !== null ? maxSendFee : selectedFee.fee;
+    const feeUsd =
+      isMaxSend && maxSendFee !== null
+        ? fiatRate !== null
+          ? maxSendFee * fiatRate
+          : undefined
+        : selectedFee.fiatAmount;
+
     navigate(`/send/${currency}/preview`, {
       state: {
         destinationAddress: states.destinationAddress,
         amount: normalizedAssetAmount,
         amountUsd: fiatRate !== null && usdAmount !== '' ? Number(usdAmount) : undefined,
-        feeAmount: selectedFee.fee,
-        feeUsd: selectedFee.fiatAmount,
+        feeAmount,
+        feeUsd,
         feeName: selectedFee.name,
         rateValue: selectedFee.rateValue,
         rateUnit: selectedFee.rateUnit,
-        sendOptions: meta.tokenSymbol
-          ? {
-              ...selectedFee.sendOptions,
-              tokenSymbol: meta.tokenSymbol,
-            }
-          : selectedFee.sendOptions,
+        sendOptions: {
+          ...selectedFee.sendOptions,
+          ...(meta.tokenSymbol ? { tokenSymbol: meta.tokenSymbol } : {}),
+          // Only BTC sweeps on the backend; ETH's max is the exact amount computed here.
+          ...(isMaxSend && meta.chain === ChainType.Bitcoin ? { isMax: true } : {}),
+        },
       },
     });
   };
@@ -365,6 +448,7 @@ export const SendOptions: React.FC = () => {
     }
 
     setError('');
+    clearMaxSend();
     setLastEditedField('asset');
     setAssetAmount(value);
   };
@@ -381,6 +465,7 @@ export const SendOptions: React.FC = () => {
     }
 
     setError('');
+    clearMaxSend();
     setLastEditedField('usd');
     setUsdAmount(value);
   };
@@ -390,16 +475,26 @@ export const SendOptions: React.FC = () => {
       return;
     }
 
-    const maxAmount = usesSeparateFeeAsset
-      ? Math.max(availableBalance, 0)
-      : Math.max(availableBalance - selectedFee.fee, 0);
-    if (usesSeparateFeeAsset && availableGasBalance !== null && availableGasBalance < selectedFee.fee) {
-      setError(`Insufficient ${meta.networkFeeSymbol} for network fee`);
-    } else {
-      setError(maxAmount <= 0 ? 'Insufficient balance' : '');
+    // Separate-fee assets (e.g. USDT paying gas in ETH): the whole balance is sendable, the
+    // fee is covered by a different asset, so there's nothing to net off.
+    if (usesSeparateFeeAsset) {
+      const maxAmount = Math.max(availableBalance, 0);
+      if (availableGasBalance !== null && availableGasBalance < selectedFee.fee) {
+        setError(`Insufficient ${meta.networkFeeSymbol} for network fee`);
+      } else {
+        setError(maxAmount <= 0 ? 'Insufficient balance' : '');
+      }
+      clearMaxSend();
+      setLastEditedField('asset');
+      setAssetAmount(formatInputAmount(maxAmount, assetDigits));
+      return;
     }
-    setLastEditedField('asset');
-    setAssetAmount(formatInputAmount(maxAmount, assetDigits));
+
+    if (meta.chain === ChainType.Bitcoin) {
+      void runBtcMaxSend();
+    } else {
+      applyNativeMaxSend();
+    }
   };
 
   if (!currency || !isSupportedSendCurrency(currency) || !states?.destinationAddress) {
@@ -421,7 +516,7 @@ export const SendOptions: React.FC = () => {
             onChange={handleAssetAmountChange}
             hasIcon={true}
             currency={currency}
-            disabled={feeEstimatesLoading || balanceLoading}
+            disabled={feeEstimatesLoading || balanceLoading || maxSendLoading}
           />
           <span className="mt-7 text-[20px]">=</span>
           <AmountInputField
@@ -442,7 +537,7 @@ export const SendOptions: React.FC = () => {
         <button
           className="flex gap-1 items-center self-end mt-2 text-sm font-medium text-center text-primary-yellow"
           onClick={handleSetMaxAmount}
-          disabled={feeEstimatesLoading || balanceLoading || !selectedFee}>
+          disabled={feeEstimatesLoading || balanceLoading || maxSendLoading || !selectedFee}>
           <span className="self-stretch my-auto">Send Max</span>
         </button>
         {usesSeparateFeeAsset && (
@@ -486,7 +581,7 @@ export const SendOptions: React.FC = () => {
         <Button
           className="mb-2"
           onClick={handleNext}
-          disabled={!assetAmount || feeEstimatesLoading || balanceLoading || !selectedFee}>
+          disabled={!assetAmount || feeEstimatesLoading || balanceLoading || maxSendLoading || !selectedFee}>
           Next
         </Button>
         {error && <div className="w-full mt-2 p-2 bg-red-600 text-center">{error}</div>}

--- a/pages/popup/src/pages/send/SendPreview.tsx
+++ b/pages/popup/src/pages/send/SendPreview.tsx
@@ -98,6 +98,8 @@ export function SendPreview() {
 
       if (errorMessage.includes('Invalid password')) {
         setError('Invalid password');
+      } else if (meta.chain === ChainType.Bitcoin && normalizedMessage.includes('max send amount changed')) {
+        setError(ERROR_MESSAGES.SEND_MAX_AMOUNT_CHANGED);
       } else if (normalizedMessage.includes('insufficient funds') || normalizedMessage.includes('insufficient')) {
         setError(ERROR_MESSAGES.SEND_TRANSACTION_INSUFFICIENT_FUNDS);
       } else if (meta.chain === ChainType.Bitcoin && normalizedMessage.includes('dust')) {


### PR DESCRIPTION
Fix issue where send max assume fee from a single UTXO where max amount can derive from multiple UTXO affecting actual fee
<img width="936" height="616" alt="image" src="https://github.com/user-attachments/assets/46c5aded-6c43-43c5-a97b-85962c119821" />
